### PR TITLE
Adds Additional Write-Progress

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,10 @@ PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jef
 
 * Removes boot delay in Stop-Lab.
 * Adds GuestIntegrationServices support.
-* Adds Write-Progress support to Reset-LabVM, New-LabVM and Remove-LabVM.
+* Adds Write-Progress support to Reset-LabVM, New-LabVM, Remove-LabVM and Test-LabConfiguration.
+* Adds -IgnorePendingReboot parameter to Start-LabConfiguration.
+* Removes extraneous verbose output from Get-CimInstance in Test-LabHostConfiguration.
+* Fixes bug in Test-LabVM where VM's prefixed name was not resolved causing calls to TestLabVMDisk and TestLabVirtualMachine to fail.
 
 ### v0.9.8
 

--- a/Src/LabHostConfiguration.ps1
+++ b/Src/LabHostConfiguration.ps1
@@ -12,7 +12,7 @@ function GetLabHostSetupConfiguration {
     [OutputType([System.Collections.Hashtable])]
     param ( )
     process {
-        [System.Boolean] $isDesktop = (Get-CimInstance -ClassName Win32_OperatingSystem).ProductType -eq 1;
+        [System.Boolean] $isDesktop = (Get-CimInstance -ClassName Win32_OperatingSystem -Verbose:$false).ProductType -eq 1;
         ## Due to the differences in client/server deployment for Hyper-V, determine the correct method before creating the host configuration array.
         $labHostSetupConfiguration = @();
 
@@ -118,7 +118,9 @@ function Test-LabHostConfiguration {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param (
-        [Parameter()] [System.Management.Automation.SwitchParameter] $IgnorePendingReboot
+        ## Skips pending reboot check
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter] $IgnorePendingReboot
     )
     process {
         WriteVerbose $localized.StartedHostConfigurationTest;

--- a/Src/LabVM.ps1
+++ b/Src/LabVM.ps1
@@ -160,9 +160,8 @@ function Test-LabVM {
         }
         foreach ($vmName in $Name) {
             $isNodeCompliant = $true;
-            WriteVerbose ($localized.TestingNodeConfiguration -f $vmName);
             $node = ResolveLabVMProperties -NodeName $vmName -ConfigurationData $ConfigurationData;
-            [ref] $null = $node.Remove('NodeName');
+            WriteVerbose ($localized.TestingNodeConfiguration -f $node.NodeDisplayName);
 
             WriteVerbose ($localized.TestingVMConfiguration -f 'Image', $node.Media);
             if (-not (Test-LabImage -Id $node.Media)) {
@@ -173,11 +172,12 @@ function Test-LabVM {
                 $isNodeCompliant = $false;
             }
             WriteVerbose ($localized.TestingVMConfiguration -f 'VHDX', $node.Media);
-            if (-not (TestLabVMDisk -Name $vmName -Media $node.Media -ErrorAction SilentlyContinue)) {
+            if (-not (TestLabVMDisk -Name $node.NodeDisplayName -Media $node.Media -ErrorAction SilentlyContinue)) {
                 $isNodeCompliant = $false;
             }
             WriteVerbose ($localized.TestingVMConfiguration -f 'VM', $vmName);
             $testLabVirtualMachineParams = @{
+                Name = $node.NodeDisplayName;
                 SwitchName = $node.SwitchName;
                 Media = $node.Media;
                 StartupMemory = $node.StartupMemory;
@@ -188,7 +188,7 @@ function Test-LabVM {
                 SecureBoot = $node.SecureBoot;
                 GuestIntegrationServices = $node.GuestIntegrationServices;
             }
-            if (-not (TestLabVirtualMachine @testLabVirtualMachineParams -Name $vmName)) {
+            if (-not (TestLabVirtualMachine @testLabVirtualMachineParams)) {
                 $isNodeCompliant = $false;
             }
             Write-Output -InputObject $isNodeCompliant;

--- a/Src/LabVMDisk.ps1
+++ b/Src/LabVMDisk.ps1
@@ -7,7 +7,7 @@ function ResolveLabVMDiskPath {
         ## VM/node name.
         [Parameter(Mandatory, ValueFromPipeline)] [ValidateNotNullOrEmpty()]
         [System.String] $Name,
-        
+
         [Parameter()] [ValidateSet('VHD','VHDX')]
         [System.String] $Generation = 'VHDX'
     )
@@ -31,7 +31,7 @@ function GetLabVMDisk {
         ## VM/node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Name,
-        
+
         ## Media Id
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.String] $Media
@@ -60,7 +60,7 @@ function TestLabVMDisk {
         ## VM/node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Name,
-        
+
         ## Media Id
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.String] $Media
@@ -91,7 +91,7 @@ function SetLabVMDisk {
         ## VM/Node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Name,
-        
+
         ## Media Id
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.String] $Media
@@ -122,7 +122,7 @@ function RemoveLabVMDisk {
         ## VM/node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Name,
-        
+
         ## Media Id
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.String] $Media
@@ -159,7 +159,7 @@ function ResetLabVMDisk {
         ## VM/node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Name,
-        
+
         ## Media Id
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.String] $Media


### PR DESCRIPTION
* Adds Write-Progress support to Reset-LabVM, New-LabVM, Remove-LabVM and Test-LabConfiguration
* Adds -IgnorePendingReboot parameter to Start-LabConfiguration
* Removes extraneous verbose output from Get-CimInstance in Test-LabHostConfiguration
* Fixes bug in Test-LabVM where VM's prefixed name was not resolved causing calls to TestLabVMDisk and TestLabVirtualMachine to fail