### PR TITLE
Fixes bug in Get-LabVM where VMs' prefixed name was not resolved correctly

### DIFF
--- a/Lib/ConfigurationData.ps1
+++ b/Lib/ConfigurationData.ps1
@@ -1,34 +1,3 @@
-function ConvertToConfigurationData {
-<#
-    .SYNOPSIS
-        Converts a file path string to a hashtable. This mimics the -ConfigurationData parameter of the
-        Start-DscConfiguration cmdlet.
-#>
-    [CmdletBinding()]
-    [OutputType([System.Collections.Hashtable])]
-    param (
-        [Parameter(Mandatory, ValueFromPipeline)]
-        [System.Object] $ConfigurationData
-    )
-    process {
-        if ($ConfigurationData -is [System.String]) {
-            $configurationDataPath = Resolve-Path -Path $ConfigurationData -ErrorAction Stop;
-            if (-not (Test-Path -Path $configurationDataPath -PathType Leaf)) {
-                throw "Invalid configuration data file";
-            }
-            elseif ([System.IO.Path]::GetExtension($configurationDataPath) -ne '.psd1') {
-                throw "Invalid configuration data file";
-            }
-            $configurationDataContent = Get-Content -Path $configurationDataPath -Raw;
-            $ConfigurationData = Invoke-Command -ScriptBlock ([System.Management.Automation.ScriptBlock]::Create($configurationDataContent));
-        }
-        if ($ConfigurationData -isnot [System.Collections.Hashtable]) {
-            throw "Invalid configuration data type";
-        }
-        return $ConfigurationData;
-    }
-} #end function ConvertToConfigurationData
-
 function ResolveConfigurationDataPath {
 <#
     .SYNOPSIS

--- a/Readme.md
+++ b/Readme.md
@@ -88,6 +88,8 @@ PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jef
 * Fixes bug in Test-LabVM where VM's prefixed name was not resolved causing calls to TestLabVMDisk and TestLabVirtualMachine to fail.
 * Adds -Force switch to Stop-Lab to ensure that locked VMs do not prevent shutdown.
 * Removes unused -UpdatePath parameter from Get/Set-LabHostDefault cmdlets.
+* Fixes bug in Get-LabVM where VMs' prefixed name was not resolved correctly.
+* Adds optional -ConfigurationData switch to Remove-LabVM to support prefixed configurations.
 
 ### v0.9.8
 

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,7 @@ PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jef
 * Removes unused -UpdatePath parameter from Get/Set-LabHostDefault cmdlets.
 * Fixes bug in Get-LabVM where VMs' prefixed name was not resolved correctly.
 * Adds optional -ConfigurationData switch to Remove-LabVM to support prefixed configurations.
+* Deprecates ConvertToConfigurationData function in favour of the native [ArgumentToConfigurationDataTransformationAttribute()].
 
 ### v0.9.8
 

--- a/Resources.psd1
+++ b/Resources.psd1
@@ -118,7 +118,7 @@ ConvertFrom-StringData -StringData @'
     ModuleNotFound                  = Module '{0}' was not found.
     ModuleFoundInPath               = Found module in '{0}'.
     CreatingQuickVM                 = Creating quick VM '{0}' using media '{1}'.
-    RemovingQuickVM                 = Removing quick VM '{0}'.
+    RemovingVM                      = Removing VM '{0}'.
     ResettingVM                     = Resetting VM '{0}'.
     CreatingInternalVirtualSwitch   = Creating Internal '{0}' virtual switch.
     TestingNodeDscModule            = Testing node DSC '{0}' module.

--- a/Src/Lab.ps1
+++ b/Src/Lab.ps1
@@ -36,9 +36,6 @@ function Start-Lab {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $nodes = @();
         $ConfigurationData.AllNodes |
@@ -113,9 +110,6 @@ function Stop-Lab {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $nodes = @();
         $ConfigurationData.AllNodes |
@@ -171,9 +165,6 @@ function Reset-Lab {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         ## Revert to Base/Lab snapshots...
         $snapshotName = $localized.BaselineSnapshotName -f $labDefaults.ModuleName;
@@ -221,9 +212,6 @@ function Checkpoint-Lab {
         ## Force snapshots if virtual machines are on
         [System.Management.Automation.SwitchParameter] $Force
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $nodes = $ConfigurationData.AllNodes | Where-Object { $_.NodeName -ne '*' } | ForEach-Object {
              ResolveLabVMProperties -NodeName $_.NodeName -ConfigurationData $ConfigurationData;
@@ -285,9 +273,6 @@ function Restore-Lab {
         ## Force snapshots if virtual machines are on
         [System.Management.Automation.SwitchParameter] $Force
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $nodes = @();
         $ConfigurationData.AllNodes |

--- a/Src/LabConfiguration.ps1
+++ b/Src/LabConfiguration.ps1
@@ -25,9 +25,6 @@ function Test-LabConfiguration {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         WriteVerbose $localized.StartedLabConfigurationTest;
         $currentNodeCount = 0;
@@ -74,9 +71,6 @@ function TestLabConfigurationMof {
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Management.Automation.SwitchParameter] $SkipMofCheck
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $Path = Resolve-Path -Path $Path -ErrorAction Stop;
         $node = $ConfigurationData.AllNodes | Where-Object { $_.NodeName -eq $Name };
@@ -230,7 +224,6 @@ function Start-LabConfiguration {
         if (-not $Credential) { throw ($localized.CannotProcessCommandError -f 'Credential'); }
         elseif ($Credential.Password.Length -eq 0) { throw ($localized.CannotBindArgumentError -f 'Password'); }
 
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
         if (-not (Test-LabHostConfiguration -IgnorePendingReboot:$IgnorePendingReboot) -and (-not $Force)) {
             throw $localized.HostConfigurationTestError;
         }
@@ -307,9 +300,6 @@ function Remove-LabConfiguration {
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Management.Automation.SwitchParameter] $RemoveSwitch
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         WriteVerbose $localized.StartedLabConfiguration;
         $nodes = $ConfigurationData.AllNodes | Where-Object { $_.NodeName -ne '*' };

--- a/Src/LabMedia.ps1
+++ b/Src/LabMedia.ps1
@@ -9,37 +9,37 @@ function NewLabMedia {
     param (
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Id = $(throw ($localized.MissingParameterError -f 'Id')),
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Filename = $(throw ($localized.MissingParameterError -f 'Filename')),
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Description = '',
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateSet('x86','x64')]
         [System.String] $Architecture = $(throw ($localized.MissingParameterError -f 'Architecture')),
-        
+
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.String] $ImageName = '',
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateSet('ISO','VHD')]
         [System.String] $MediaType = $(throw ($localized.MissingParameterError -f 'MediaType')),
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Uri = $(throw ($localized.MissingParameterError -f 'Uri')),
-        
+
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.String] $Checksum = '',
-        
+
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.String] $ProductKey = '',
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateSet('Windows','Linux')]
         [System.String] $OperatingSystem = 'Windows',
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNull()]
         [System.Collections.Hashtable] $CustomData = @{},
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [AllowNull()]
         [System.Array] $Hotfixes
     )
@@ -82,7 +82,7 @@ function ResolveLabMedia {
         Resolves the specified media using the registered media and configuration data.
     .DESCRIPTION
         Resolves the specified lab media from the registered media, but permitting the defaults to be overridden by configuration data.
-        
+
         This also permits specifying of media within Configuration Data and not having to be registered on the lab host.
 #>
     [CmdletBinding()]
@@ -90,7 +90,7 @@ function ResolveLabMedia {
         ## Media ID
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Id,
-        
+
         ## Lab DSC configuration data
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Collections.Hashtable]
@@ -100,10 +100,9 @@ function ResolveLabMedia {
     process {
         ## Avoid any $media variable scoping issues
         $media = $null;
-        
+
         ## If we have configuration data specific instance, return that
         if ($PSBoundParameters.ContainsKey('ConfigurationData')) {
-            $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
             $customMedia = $ConfigurationData.NonNodeData.$($labDefaults.ModuleName).Media.Where({ $_.Id -eq $Id });
             if ($customMedia) {
                 $mediaHash = @{};
@@ -113,23 +112,23 @@ function ResolveLabMedia {
                 $media = NewLabMedia @mediaHash;
             }
         }
-        
+
         ## If we have custom media, return that
         if (-not $media) {
             $media = GetConfigurationData -Configuration CustomMedia;
             $media = $media | Where-Object { $_.Id -eq $Id };
         }
-        
+
         ## If we still don't have a media image, return the built-in object
         if (-not $media) {
             $media = Get-LabMedia -Id $Id;
         }
-        
+
         ## We don't have any defined, custom or built-in media
         if (-not $media) {
             throw ($localized.CannotLocateMediaError -f $Id);
         }
-        
+
         return $media;
     } #end process
 } #end function ResolveLabMedia
@@ -151,7 +150,7 @@ function Get-LabMedia {
         ## Media ID
         [Parameter(ValueFromPipeline)] [ValidateNotNullOrEmpty()]
         [System.String] $Id,
-        
+
         ## Only return custom media
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Management.Automation.SwitchParameter] $CustomOnly
@@ -250,7 +249,7 @@ function InvokeLabMediaImageDownload {
         ## Lab media object
         [Parameter(Mandatory, ValueFromPipeline)] [ValidateNotNull()]
         [System.Object] $Media,
-        
+
         ## Force (re)download of the resource
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Management.Automation.SwitchParameter] $Force
@@ -266,13 +265,13 @@ function InvokeLabMediaImageDownload {
         if ($media.MediaType -eq 'VHD') {
             $invokeResourceDownloadParams['DestinationPath'] = Join-Path -Path $hostDefaults.ParentVhdPath -ChildPath $media.Filename;
         }
-        
+
         $mediaUri = New-Object -TypeName System.Uri -ArgumentList $Media.Uri;
         if ($mediaUri.Scheme -eq 'File') {
             ## Use a bigger buffer for local file copies..
             $invokeResourceDownloadParams['BufferSize'] = 1MB;
         }
-        
+
         if ($media.MediaType -eq 'VHD') {
             ## Always download VHDXs regardless of Uri type
             [ref] $null = InvokeResourceDownload @invokeResourceDownloadParams -Force:$Force;
@@ -309,13 +308,13 @@ function InvokeLabMediaHotfixDownload {
     param (
         [Parameter(Mandatory, ValueFromPipeline)] [ValidateNotNullOrEmpty()]
         [System.String] $Id,
-        
+
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Uri,
-        
+
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Checksum,
-        
+
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Management.Automation.SwitchParameter] $Force
     )
@@ -342,7 +341,7 @@ function Register-LabMedia {
         The Register-LabMedia cmdlet allows adding custom media to the host's configuration. This circumvents the requirement of having to define custom media entries in the DSC configuration document (.psd1).
 
         You can use the Register-LabMedia cmdlet to override the default media entries, e.g. you have the media hosted internally or you wish to replace the built-in media with your own implementation.
-        
+
         To override a built-in media entry, specify the same media Id with the -Force switch.
     .LINK
         Get-LabMedia
@@ -353,47 +352,47 @@ function Register-LabMedia {
         ## Specifies the media Id to register. You can override the built-in media if required.
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [System.String] $Id,
-        
+
         ## Specifies the media's type.
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateSet('VHD','ISO','WIM')]
         [System.String] $MediaType,
-        
+
         ## Specifies the source Uri (http/https/file) of the media.
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.Uri] $Uri,
-        
+
         ## Specifies the architecture of the media.
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateSet('x64','x86')]
         [System.String] $Architecture,
-        
+
         ## Specifies a description of the media.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Description,
-        
+
         ## Specifies the image name containing the target WIM image. You can specify integer values.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $ImageName,
-        
+
         ## Specifies the local filename of the locally cached resource file.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Filename,
-        
+
         ## Specifies the MD5 checksum of the resource file.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $Checksum,
-        
-        ## Specifies custom data for the media. 
+
+        ## Specifies custom data for the media.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNull()]
         [System.Collections.Hashtable] $CustomData,
-        
+
         ## Specifies additional Windows hotfixes to install post deployment.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNull()]
         [System.Collections.Hashtable[]] $Hotfixes,
-        
+
         ## Specifies the media type. Linux VHD(X)s do not inject resources.
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateSet('Windows','Linux')]
         [System.String] $OperatingSystem = 'Windows',
-        
+
         ## Specifies that an exiting media entry should be overwritten.
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.Management.Automation.SwitchParameter] $Force
@@ -403,7 +402,7 @@ function Register-LabMedia {
         if (($OperatingSystem -eq 'Linux') -and ($MediaType -ne 'VHD')) {
             throw ($localized.InvalidOSMediaTypeError -f $MediaType, $OperatingSystem);
         }
-        
+
         ## Validate ImageName when media type is ISO/WIM
         if (($MediaType -eq 'ISO') -or ($MediaType -eq 'WIM')) {
             if (-not $PSBoundParameters.ContainsKey('ImageName')) {
@@ -416,13 +415,13 @@ function Register-LabMedia {
         if ($media -and (-not $Force)) {
             throw ($localized.MediaAlreadyRegisteredError -f $Id, '-Force');
         }
-    
+
         ## Get the custom media list (not the built in media)
         $existingCustomMedia = @(GetConfigurationData -Configuration CustomMedia);
         if (-not $existingCustomMedia) {
             $existingCustomMedia = @();
         }
-    
+
         $customMedia = [PSCustomObject] @{
             Id = $Id;
             Filename = $Filename;
@@ -451,11 +450,11 @@ function Register-LabMedia {
             WriteVerbose ($localized.AddingCustomMediaEntry -f $Id);
             $existingCustomMedia += $customMedia;
         }
-    
+
         WriteVerbose ($localized.SavingConfiguration -f $Id);
         SetConfigurationData -Configuration CustomMedia -InputObject @($existingCustomMedia);
         return $customMedia;
-    
+
     } #end process
 } #end function Register-LabMedia
 
@@ -494,7 +493,7 @@ function Unregister-LabMedia {
                 return;
             }
         }
-        
+
         $shouldProcessMessage = $localized.PerformingOperationOnTarget -f 'Unregister-LabMedia', $Id;
         $verboseProcessMessage = $localized.RemovingCustomMediaEntry -f $Id;
         if ($PSCmdlet.ShouldProcess($verboseProcessMessage, $shouldProcessMessage, $localized.ShouldProcessWarning)) {
@@ -503,7 +502,7 @@ function Unregister-LabMedia {
             SetConfigurationData -Configuration CustomMedia -InputObject @($customMedia);
             return $media;
         }
-        
+
     } #end process
 } #end function Unregister-LabMedia
 

--- a/Src/LabResource.ps1
+++ b/Src/LabResource.ps1
@@ -21,7 +21,6 @@ function Test-LabResource {
         [System.String] $ResourcePath
     )
     begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
         if (-not $ResourcePath) {
             $hostDefaults = GetConfigurationData -Configuration Host;
             $ResourcePath = $hostDefaults.ResourcePath;
@@ -188,7 +187,6 @@ function Invoke-LabResourceDownload {
         [System.Management.Automation.SwitchParameter] $Force
     )
     begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
         $hostDefaults = GetConfigurationData -Configuration Host;
         if (-not $DestinationPath) { $DestinationPath = $hostDefaults.ResourcePath; }
     }
@@ -346,7 +344,6 @@ function ExpandLabResource {
         [System.String] $ResourcePath
     )
     begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
         if (-not $ResourcePath) {
             $hostDefaults = GetConfigurationData -Configuration Host;
             $ResourcePath = $hostDefaults.ResourcePath;

--- a/Src/LabSwitch.ps1
+++ b/Src/LabSwitch.ps1
@@ -67,9 +67,6 @@ function ResolveLabSwitch {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $networkSwitch = $ConfigurationData.NonNodeData.$($labDefaults.ModuleName).Network.Where({ $_.Name -eq $Name });
         if ($networkSwitch) {
@@ -121,9 +118,6 @@ function TestLabSwitch {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    }
     process {
         $networkSwitch = ResolveLabSwitch @PSBoundParameters;
         if (($null -ne $networkSwitch.IsExisting) -and ($networkSwitch.IsExisting -eq $true)) {
@@ -154,9 +148,6 @@ function SetLabSwitch {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    } #end begin
     process {
         $networkSwitch = ResolveLabSwitch @PSBoundParameters;
         if (($null -eq $networkSwitch.IsExisting) -or ($networkSwitch.IsExisting -eq $false)) {
@@ -185,9 +176,6 @@ function RemoveLabSwitch {
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData
     )
-    begin {
-        $ConfigurationData = ConvertToConfigurationData -ConfigurationData $ConfigurationData;
-    } #end begin
     process {
         $networkSwitch = ResolveLabSwitch @PSBoundParameters;
         if (($null -eq $networkSwitch.IsExisting) -or ($networkSwitch.IsExisting -eq $false)) {

--- a/Tests/Lib/ConfigurationData.Tests.ps1
+++ b/Tests/Lib/ConfigurationData.Tests.ps1
@@ -13,36 +13,6 @@ Describe 'ConfigurationData' {
 
     InModuleScope $moduleName {
 
-        Context 'Validates "ConvertToConfigurationData" method' {
-
-            It 'Returns a "System.Collections.Hashtable" type' {
-                $configurationData = ConvertToConfigurationData -ConfigurationData @{};
-                $configurationData -is [System.Collections.Hashtable] | Should Be $true;
-            }
-
-            It 'Returns a "System.Collections.Hashtable" type from a file path' {
-                $configurationDataPath = "TestDrive:\ConvertToConfigurationData.psd1";
-                Set-Content -Path $configurationDataPath -Value '@{ Node = "Test"; }';
-                $configurationData = ConvertToConfigurationData -ConfigurationData $configurationDataPath;
-                $configurationData -is [System.Collections.Hashtable] | Should Be $true;
-            }
-
-            It 'Throws when passed a directory path' {
-                { ConvertToConfigurationData -ConfigurationData TestDrive:\ } | Should Throw;
-            }
-
-            It 'Throws when passed a file path with an extension other than ".psd1"' {
-                $testPath = "TestDrive:\ConfigurationData.ps1";
-                New-Item -Path $testPath -ItemType File -Force;
-                { ConvertToConfigurationData -ConfigurationData $testPath } | Should Throw;
-            }
-
-            It 'Throws when passed a non-string or non-hashtable' {
-                { ConvertToConfigurationData -ConfigurationData (Get-Date) } | Should Throw;
-            }
-
-        } #end context Validates "ConvertToConfigurationData" method
-
         Context 'Validates "ResolveConfigurationDataPath" method' {
 
             foreach ($config in @('Host','VM','Media','CustomMedia')) {

--- a/Tests/Src/LabConfiguration.Tests.ps1
+++ b/Tests/Src/LabConfiguration.Tests.ps1
@@ -14,14 +14,13 @@ Describe 'LabConfiguration' {
     InModuleScope $moduleName {
 
         Context 'Validates "Test-LabConfiguration" method' {
-            
+
             It 'Calls "Test-LabVM" for each node' {
                 $configurationData = @{
                     AllNodes = @(
                         @{ NodeName = 'VM1'; }, @{ NodeName = 'VM2'; }, @{ NodeName = 'VM3'; }
                     )
                 }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Test-LabVM -MockWith { }
 
                 Test-LabConfiguration -ConfigurationData $configurationData;
@@ -36,7 +35,6 @@ Describe 'LabConfiguration' {
             It 'Throws if path is invalid' {
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
 
                 { TestLabConfigurationMof -ConfigurationData $configurationData -Name $testVM -Path 'TestDrive:\InvalidPath' } | Should Throw;
             }
@@ -45,7 +43,6 @@ Describe 'LabConfiguration' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testPath\$testVM.mof" -ItemType File -Force;
                 New-Item -Path "$testPath\$testVM.meta.mof" -ItemType File -Force;
 
@@ -56,7 +53,6 @@ Describe 'LabConfiguration' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Remove-Item -Path "$testPath\$testVM.mof" -Force -ErrorAction SilentlyContinue;
                 Remove-Item -Path "$testPath\$testVM.meta.mof" -Force -ErrorAction SilentlyContinue;
 
@@ -67,7 +63,6 @@ Describe 'LabConfiguration' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testPath\$testVM.mof" -ItemType File -Force;
                 Remove-Item -Path "$testPath\$testVM.meta.mof" -Force -ErrorAction SilentlyContinue;
 
@@ -78,7 +73,6 @@ Describe 'LabConfiguration' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Remove-Item -Path "$testPath\$testVM.mof" -Force -ErrorAction SilentlyContinue;
                 Remove-Item -Path "$testPath\$testVM.meta.mof" -Force -ErrorAction SilentlyContinue;
 
@@ -94,7 +88,6 @@ Describe 'LabConfiguration' {
             It 'Throws is "Test-LabHostConfiguration" fails' {
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Test-LabHostConfiguration -MockWith { return $false; }
 
                 { Start-LabConfiguration -ConfigurationData $configurationData -Credential $testPassword } | Should Throw;
@@ -103,17 +96,15 @@ Describe 'LabConfiguration' {
             It 'Throws if path is invalid' {
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Test-LabHostConfiguration -MockWith { return $true; }
 
                 { Start-LabConfiguration -ConfigurationData $configurationData -Path 'TestDrive:\InvalidPath'  -Credential $testPassword } | Should Throw;
             }
-            
+
             It 'Calls "NewLabVM" if node is not configured' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Test-LabHostConfiguration -MockWith { return $true; }
                 Mock TestLabConfigurationMof -MockWith { }
                 Mock NewLabVM -ParameterFilter { $Name -eq $testVM } -MockWith { }
@@ -128,7 +119,6 @@ Describe 'LabConfiguration' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Test-LabHostConfiguration -MockWith { return $true; }
                 Mock TestLabConfigurationMof -MockWith { }
                 Mock NewLabVM -ParameterFilter { $Name -eq $testVM } -MockWith { }
@@ -143,7 +133,6 @@ Describe 'LabConfiguration' {
                 $testPath = 'TestDrive:';
                 $testVM = 'VM1';
                 $configurationData = @{ AllNodes = @( @{ NodeName = $testVM; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Test-LabHostConfiguration -MockWith { return $true; }
                 Mock TestLabConfigurationMof -MockWith { }
                 Mock NewLabVM -ParameterFilter { $Name -eq $testVM } -MockWith { }
@@ -160,7 +149,6 @@ Describe 'LabConfiguration' {
 
             It 'Calls "RemoveLabVM" for each node' {
                 $configurationData = @{ AllNodes = @( @{ NodeName = 'VM1'; }, @{ NodeName = 'VM2'; } ) }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock RemoveLabVM -MockWith { }
 
                 Remove-LabConfiguration -ConfigurationData $configurationData;

--- a/Tests/Src/LabMedia.Tests.ps1
+++ b/Tests/Src/LabMedia.Tests.ps1
@@ -10,11 +10,11 @@ $repoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path;
 Import-Module (Join-Path -Path $RepoRoot -ChildPath "$moduleName.psm1") -Force;
 
 Describe 'LabMedia' {
-    
+
     InModuleScope $moduleName {
 
         Context 'Validates "NewLabMedia" method' {
-            
+
             $newLabMediaParams = @{
                 Id = 'Test-Media';
                 Filename = 'Test-Media.iso';
@@ -23,17 +23,17 @@ Describe 'LabMedia' {
                 Uri = 'http://testmedia.com/test-media.iso';
                 #CustomData = @{ };
             }
-        
+
             It 'Does not throw with valid mandatory parameters' {
                 { NewLabMedia @newLabMediaParams } | Should Not Throw;
             }
-        
+
             It 'Throws with an invalid Uri' {
                 $testLabMediaParams = $newLabMediaParams.Clone();
                 $testLabMediaParams['Uri'] = 'about:blank';
                 { NewLabMedia @testLabMediaParams } | Should Throw;
             }
-        
+
             foreach ($parameter in @('Id','Filename','Architecture','MediaType','Uri')) {
                 It "Throws when ""$parameter"" parameter is missing" {
                     $testLabMediaParams = $newLabMediaParams.Clone();
@@ -41,24 +41,22 @@ Describe 'LabMedia' {
                     { NewLabMedia @testLabMediaParams } | Should Throw;
                 }
             }
-        
-            
-        
+
             It 'Returns "System.Management.Automation.PSCustomObject" object type' {
                 $labMedia = NewLabMedia @newLabMediaParams;
                 $labMedia -is [System.Management.Automation.PSCustomObject] | Should Be $true;
             }
-        
+
             It 'Creates ProductKey custom entry when "ProductKey" is specified' {
                 $testProductKey = 'ABCDE-12345-FGHIJ-67890-KLMNO';
                 $labMedia = NewLabMedia @newLabMediaParams -ProductKey $testProductKey;
                 $labMedia.CustomData.ProductKey | Should Be $testProductKey;
             }
-        
+
         } #end context Validates "NewLabMedia" method
-        
+
         Context 'Validates "ResolveLabMedia" method' {
-        
+
             It 'Throws if media Id cannot be resolved' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testMediaFilename = 'test-media.iso';
@@ -73,11 +71,10 @@ Describe 'LabMedia' {
                                     MediaType = 'ISO';
                                     Uri = 'http://testmedia.com/test-media.iso';
                                     CustomData = @{ }; } ) } } }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
-        
+
                 { ResolveLabMedia -Id NonExistentMediaId -ConfigurationData $configurationData } | Should Throw;
             }
-        
+
             It 'Returns configuration data media entry if it exists' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testMediaFilename = 'test-media.iso';
@@ -92,54 +89,52 @@ Describe 'LabMedia' {
                                     MediaType = 'ISO';
                                     Uri = 'http://testmedia.com/test-media.iso';
                                     CustomData = @{ }; } ) } } }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
-        
+
                 $labMedia = ResolveLabMedia -Id $testMediaId -ConfigurationData $configurationData;
-        
+
                 $labMedia.Filename | Should Be $testMediaFilename;
             }
-        
+
             It 'Returns default media if configuration data entry does not exist' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $configurationData = @{
                     NonNodeData = @{
                         $labDefaults.ModuleName = @{ } } }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
-        
+
                 $labMedia = ResolveLabMedia -Id $testMediaId -ConfigurationData $configurationData;
-        
+
                 $labMedia.Id | Should Be $testMediaId
                 $labMedia.Filename | Should Not BeNullOrEmpty;
             }
-        
+
         } #end context Validates "ResolveLabMedia" method
-        
+
         Context 'Validates "Get-LabMedia" method' {
-        
+
             It 'Returns all built-in media when no "Id" is specified' {
                 $labMedia = Get-LabMedia;
-        
+
                 $labMedia.Count -gt 1 | Should Be $true;
             }
-        
+
             It 'Returns a single matching built-in media when "Id" is specified' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $labMedia = Get-LabMedia -Id $testMediaId;
-        
+
                 $labMedia | Should Not BeNullOrEmpty;
                 $labMedia.Count | Should BeNullOrEmpty;
             }
-        
+
             It 'Returns null if no built-in media is found when "Id" is specified' {
                 $labMedia = Get-LabMedia -Id 'NonExistentMediaId';
-        
+
                 $labMedia | Should BeNullOrEmpty;
             }
-        
+
         } #end context Validates "Get-LabMedia" method
-        
+
         Context 'Validates "Test-LabMedia" method' {
-        
+
             It 'Passes when media ISO has been downloaded' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testHostIsoPath = 'TestDrive:';
@@ -148,10 +143,10 @@ Describe 'LabMedia' {
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] @{ IsoPath = $testHostIsoPath; } }
                 New-Item -Path "$testHostIsoPath\$testMediaFilename" -ItemType File -Force -ErrorAction SilentlyContinue;
                 Mock Get-LabMedia -ParameterFilter { $Id -eq $testMediaId } -MockWith { return [PSCustomObject] $fakeLabMedia; }
-        
+
                 Test-LabMedia -Id $testMediaId | Should Be $true;
             }
-        
+
             It 'Fails when media ISO has not been downloaded' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testHostIsoPath = 'TestDrive:';
@@ -160,10 +155,10 @@ Describe 'LabMedia' {
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] @{ IsoPath = $testHostIsoPath; } }
                 Remove-Item -Path "$testHostIsoPath\$testMediaFilename" -Force -ErrorAction SilentlyContinue;
                 Mock Get-LabMedia -ParameterFilter { $Id -eq $testMediaId } -MockWith { return [PSCustomObject] $fakeLabMedia; }
-        
+
                 Test-LabMedia -Id $testMediaId | Should Be $false;
             }
-        
+
             It 'Fails when media Id is not found' {
                 $testMediaId = 'NonExistentMediaId';
                 $testHostIsoPath = 'TestDrive:';
@@ -171,14 +166,14 @@ Describe 'LabMedia' {
                 $fakeLabMedia = @{ Filename = $testMediaFilename; Uri = 'http//testmedia.com/test-media.iso'; Checksum = ''; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] @{ IsoPath = $testHostIsoPath; } }
                 Mock Get-LabMedia -ParameterFilter { $Id -eq $testMediaId } -MockWith { }
-        
+
                 Test-LabMedia -Id $testMediaId | Should Be $false;
             }
-        
+
         } #end context Validates "Test-LabMedia" method
-        
+
         Context 'Validates "InvokeLabMediaImageDownload" method' {
-        
+
             It 'Returns a "System.IO.FileInfo" object type' {
                 $testMediaId = 'NonExistentMediaId';
                 $testMediaType = 'ISO';
@@ -189,11 +184,11 @@ Describe 'LabMedia' {
                 New-Item -Path "$testHostIsoPath\$testMediaFilename" -ItemType File -Force -ErrorAction SilentlyContinue;
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return $fakeConfigurationData; }
                 Mock InvokeResourceDownload -MockWith { }
-        
+
                 $fileInfo = InvokeLabMediaImageDownload -Media $fakeLabMedia;;
                 $fileInfo -is [System.IO.FileInfo] | Should Be $true;
             }
-        
+
             It 'Calls "InvokeResourceDownload" with "ParentVhdPath" if media type is "VHD"' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testMediaFilename = "$testMediaId.vhdx";
@@ -206,12 +201,12 @@ Describe 'LabMedia' {
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $DestinationPath -like $testImagePath } -MockWith { }
                 Mock InvokeResourceDownload { Write-Host $Destinationpath -ForegroundColor Yellow }
-        
+
                 InvokeLabMediaImageDownload -Media $fakeLabMedia;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $DestinationPath -like $testImagePath } -Scope It;
             }
-        
+
             It 'Calls "InvokeResourceDownload" with "IsoPath" if media type is "ISO"' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testMediaFilename = "$testMediaId.iso";
@@ -222,9 +217,9 @@ Describe 'LabMedia' {
                 $fakeLabMedia = @{ Id = $testMediaId; Filename = $testMediaFilename; Uri = "http://testmedia.com/$testMediaFilename"; Checksum = ''; MediaType = 'ISO'; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $DestinationPath -like $testImagePath } -MockWith { }
-        
+
                 InvokeLabMediaImageDownload -Media $fakeLabMedia;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $DestinationPath -like $testImagePath } -Scope It;
             }
 
@@ -238,12 +233,12 @@ Describe 'LabMedia' {
                 $fakeLabMedia = @{ Id = $testMediaId; Filename = $testMediaFilename; Uri = "http://testmedia.com/$testMediaFilename"; Checksum = ''; MediaType = 'WIM'; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $DestinationPath -like $testImagePath } -MockWith { }
-        
+
                 InvokeLabMediaImageDownload -Media $fakeLabMedia;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $DestinationPath -like $testImagePath } -Scope It;
             }
-        
+
             It 'Calls "InvokeResourceDownload" with "Force" parameter when specified' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testMediaFilename = "$testMediaId.iso";
@@ -254,12 +249,12 @@ Describe 'LabMedia' {
                 $fakeLabMedia = @{ Id = $testMediaId; Filename = $testMediaFilename; Uri = "http://testmedia.com/$testMediaFilename"; Checksum = ''; MediaType = 'ISO'; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $Force -eq $true } -MockWith { }
-        
+
                 InvokeLabMediaImageDownload -Media $fakeLabMedia -Force;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $Force -eq $true } -Scope It;
             }
-        
+
             It 'Calls "InvokeResourceDownload" with large "BufferSize" for file Uris' {
                 $testMediaId = '2012R2_x64_Standard_EN_Eval';
                 $testMediaFilename = "$testMediaId.wim";
@@ -270,9 +265,9 @@ Describe 'LabMedia' {
                 $fakeLabMedia = @{ Id = $testMediaId; Filename = $testMediaFilename; Uri = "file://testmedia.com/$testMediaFilename"; Checksum = ''; MediaType = 'WIM'; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $BufferSize -gt 64KB } -MockWith { }
-        
+
                 InvokeLabMediaImageDownload -Media $fakeLabMedia;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $BufferSize -gt 64KB } -Scope It;
             }
 
@@ -286,9 +281,9 @@ Describe 'LabMedia' {
                 $fakeLabMedia = @{ Id = $testMediaId; Filename = $testMediaFilename; Uri = "file://$testImagePath"; Checksum = ''; MediaType = 'WIM'; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -MockWith { }
-        
+
                 InvokeLabMediaImageDownload -Media $fakeLabMedia;
-        
+
                 Assert-MockCalled InvokeResourceDownload -Scope It -Exactly 0;
             }
 
@@ -301,16 +296,16 @@ Describe 'LabMedia' {
                 $fakeConfigurationData = @{ IsoPath = $testHostIsoPath; DisableLocalFileCaching = $true; }
                 $fakeLabMedia = @{ Id = $testMediaId; Filename = $testMediaFilename; Uri = "file://$testImagePath"; Checksum = ''; MediaType = 'WIM'; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-        
+
                 $media = InvokeLabMediaImageDownload -Media $fakeLabMedia;
-            
+
                 $media.FullName | Should Be $testImagePath;
             }
-        
+
         } #end context Validates "InvokeLabMediaImageDownload" method
-        
+
         Context 'Validates "InvokeLabMediaHotfixDownload" method' {
-        
+
             It 'Returns a "System.IO.FileInfo" object type' {
                 $testHotfixId = 'Windows11-KB1234567.msu';
                 $testHotfixUri = "http://testhotfix.com/$testHotfixId";
@@ -320,11 +315,11 @@ Describe 'LabMedia' {
                 $fakeConfigurationData = @{ HotfixPath = $testHotfixPath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $DestinationPath -eq $testHotfixFilename } -MockWith { }
-        
+
                 $hotfix = InvokeLabMediaHotfixDownload -Id $testHotfixId -Uri $testHotfixUri;
                 $hotfix -is [System.IO.FileInfo] | Should Be $true;
             }
-        
+
             It 'Calls "InvokeResourceDownload" with "Checksum" parameter when specified' {
                 $testHotfixId = 'Windows11-KB1234567.msu';
                 $testHotfixUri = "http://testhotfix.com/$testHotfixId";
@@ -335,12 +330,12 @@ Describe 'LabMedia' {
                 $fakeConfigurationData = @{ HotfixPath = $testHotfixPath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $Checksum -eq $testHotfixChecksum } -MockWith { }
-        
+
                 InvokeLabMediaHotfixDownload -Id $testHotfixId -Uri $testHotfixUri -Checksum $testHotfixChecksum;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $Checksum -eq $testHotfixChecksum } -Scope It;
             }
-        
+
             It 'Calls "InvokeResourceDownload" with "Force" parameter when specified' {
                 $testHotfixId = 'Windows11-KB1234567.msu';
                 $testHotfixUri = "http://testhotfix.com/$testHotfixId";
@@ -350,16 +345,16 @@ Describe 'LabMedia' {
                 $fakeConfigurationData = @{ HotfixPath = $testHotfixPath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
                 Mock InvokeResourceDownload -ParameterFilter { $Force -eq $true } -MockWith { }
-        
+
                 InvokeLabMediaHotfixDownload -Id $testHotfixId -Uri $testHotfixUri -Force;
-        
+
                 Assert-MockCalled InvokeResourceDownload -ParameterFilter { $Force -eq $true } -Scope It;
             }
-        
+
         } #end context Validates "InvokeLabMediaHotfixDownload" method
-        
+
         Context 'Validates "Register-LabMedia" method' {
-        
+
             $testMediaParams = @{
                 Id = 'TestId';
                 Uri = 'http://contoso.com/testmedia';
@@ -369,7 +364,7 @@ Describe 'LabMedia' {
                 [PSObject] $testMediaParams,
                 [PSObject] @{ Id = 'TestId2'; Uri = 'http://contoso.com/testmedia'; Architecture = 'x64'; }
             )
-            
+
             It 'Throws when custom media type is "ISO" and OperatingSystem is "Linux"' {
                 { Register-LabMedia @testMediaParams -OperatingSystem Linux -MediaType ISO } | Should Throw;
             }
@@ -377,37 +372,37 @@ Describe 'LabMedia' {
             It 'Throws when custom media type is "WIM" and OperatingSystem is "Linux"' {
                 { Register-LabMedia @testMediaParams -OperatingSystem Linux -MediaType WIM } | Should Throw;
             }
-        
+
             It 'Throws when custom media type is "ISO" and "ImageName" is not specified' {
                 { Register-LabMedia @testMediaParams -MediaType ISO } | Should Throw;
             }
-            
+
             It 'Throws when custom media type is "WIM" and "ImageName" is not specified' {
                 { Register-LabMedia @testMediaParams -MediaType WIM } | Should Throw;
             }
-            
+
             It 'Throws when custom media already exists and "Force" is not specified' {
                 Mock ResolveLabMedia { return $testCustomMedia[0]; }
-                
+
                 { Register-LabMedia @testMediaParams -MediaType VHD -WarningAction SilentlyContinue } | Should Throw;
             }
-        
+
             It 'Does not throw when custom media type is "VHD" and "ImageName" is not specified' {
                 Mock ResolveLabMedia { }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'CustomMedia' } -MockWith { };
                 Mock SetConfigurationData { }
-                
+
                 { Register-LabMedia @testMediaParams -MediaType VHD -WarningAction SilentlyContinue } | Should Not Throw;
             }
-        
+
             It 'Does not throw when custom media already exists and "Force" is specified' {
                 Mock ResolveLabMedia { return $testCustomMedia[0]; }
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'CustomMedia' } -MockWith { return $testCustomMedia; };
                 Mock SetConfigurationData { }
-                
+
                 { Register-LabMedia @testMediaParams -MediaType VHD -Force -WarningAction SilentlyContinue } | Should Not Throw;
             }
-        
+
         } #end context Validates "Register-LabMedia" method
 
         Context 'Validates "Unregister-LabMedia" method' {
@@ -418,28 +413,28 @@ Describe 'LabMedia' {
             )
 
             It "Removes existing custom media entry when 'Id' does exist" {
-                
+
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'CustomMedia' } -MockWith { return $testCustomMedia; };
                 Mock SetConfigurationData { }
 
                 Unregister-LabMedia -Id $testMediaId -WarningAction SilentlyContinue;
-                
+
                 Assert-MockCalled SetConfigurationData -ParameterFilter { $InputObject.Count -eq ($testCustomMedia.Count -1) } -Scope It;
 
             }
 
             It "Does not remove any entries when custom media 'Id' doesn't exist" {
-                
+
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'CustomMedia' } -MockWith { return $testCustomMedia; };
                 Mock SetConfigurationData { }
 
                 Unregister-LabMedia -Id 'Non-existent' -WarningAction SilentlyContinue;
-                
+
                 Assert-MockCalled SetConfigurationData -Scope It -Exactly 0;
             }
 
         } #end context Validates "Unregister-LabMedia" method
-            
+
     } #end InModuleScope
 
 } #end describe LabMedia

--- a/Tests/Src/LabResource.Tests.ps1
+++ b/Tests/Src/LabResource.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'LabResource' {
 
     InModuleScope $moduleName {
 
-        Context 'Validates "Get-LabHostDefault" method' {
+        Context 'Validates "Test-LabResource" method' {
 
             $configurationData = @{
                 NonNodeData = @{
@@ -28,16 +28,14 @@ Describe 'LabResource' {
                 $emptyConfigurationData = @{ NonNodeData = @{ $labDefaults.ModuleName = @{ Resource = @( ) } } }
                 $fakeConfigurationData = @{ ResourcePath = $testResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $emptyConfigurationData; }
 
-                Test-LabResource -ConfigurationData $configurationData | Should Be $true;
+                Test-LabResource -ConfigurationData $emptyConfigurationData | Should Be $true;
             }
 
             It 'Passes when all defined resources are present and "Id" parameter is not specified' {
                 $testResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 foreach ($resource in $configurationData.NonNodeData.$($labDefaults.ModuleName).Resource) {
                     New-Item -Path "$testResourcePath\$($resource.Id)" -ItemType File -Force -ErrorAction SilentlyContinue;
                 }
@@ -50,7 +48,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testHostResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
 
                 Test-LabResource -ConfigurationData $configurationData -ResourceId $testResourceId | Should Be $true;
@@ -61,7 +58,6 @@ Describe 'LabResource' {
                 $testResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 foreach ($resource in $configurationData.NonNodeData.$($labDefaults.ModuleName).Resource) {
                     New-Item -Path "$testResourcePath\$($resource.Id)" -ItemType File -Force -ErrorAction SilentlyContinue;
                 }
@@ -75,7 +71,6 @@ Describe 'LabResource' {
                 $testResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 foreach ($resource in $configurationData.NonNodeData.$($labDefaults.ModuleName).Resource) {
                     New-Item -Path "$testResourcePath\$($resource.Id)" -ItemType File -Force -ErrorAction SilentlyContinue;
                 }
@@ -97,7 +92,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testHostResourcePath\$testResourceFilename" -ItemType File -Force -ErrorAction SilentlyContinue;
 
                 Test-LabResource -ConfigurationData $filenameConfigurationData -ResourceId $testResourceId | Should Be $true;
@@ -116,7 +110,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock TestResourceDownload -ParameterFilter { $Checksum -eq $testResourceChecksum } -MockWith { return $true; }
 
                 Test-LabResource -ConfigurationData $checksumConfigurationData;
@@ -395,7 +388,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Remove-Item -Path $testHostResourcePath -Force -ErrorAction SilentlyContinue;
 
                 ExpandLabResource -ConfigurationData $configurationData -Name $testVM -DestinationPath $testHostResourcePath;
@@ -420,7 +412,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Copy-Item -MockWith { }
                 Mock Invoke-LabResourceDownload -ParameterFilter { $ResourceId -eq $testResourceId } -MockWith {
                    New-Item -Path "$testHostResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
@@ -450,7 +441,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock Copy-Item -MockWith { }
                 Mock Invoke-LabResourceDownload -ParameterFilter { $ResourceId -eq $testResourceId } -MockWith {
                    New-Item -Path "$testHostResourcePath\$testResourceFilename" -ItemType File -Force -ErrorAction SilentlyContinue;
@@ -479,7 +469,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testHostResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
                 Mock Copy-Item -ParameterFilter { $Destination -eq $testHostResourcePath -and $Force -eq $true } -MockWith { }
 
@@ -509,7 +498,6 @@ Describe 'LabResource' {
                 }
                 $fakeConfigurationData = @{ ResourcePath = "TestDrive:\$defaultDestinationPath";}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
                 Mock Copy-Item -ParameterFilter { $Destination -eq $testResourcePath -and $Force -eq $true } -MockWith { }
 
@@ -536,7 +524,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testHostResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
                 Mock ExpandZipArchive -MockWith { }
 
@@ -565,7 +552,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock ExpandZipArchive -ParameterFilter { $DestinationPath -eq $testResourcePath } -MockWith { }
 
                 ExpandLabResource -ConfigurationData $configurationData -Name $testVM -DestinationPath $testHostResourcePath;
@@ -591,7 +577,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testHostResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
                 Mock ExpandIsoResource -MockWith { }
 
@@ -621,7 +606,6 @@ Describe 'LabResource' {
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
 
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 Mock ExpandIsoResource -ParameterFilter { $DestinationPath -eq $testResourcePath } -MockWith { }
 
                 ExpandLabResource -ConfigurationData $configurationData -Name $testVM -DestinationPath $testHostResourcePath;
@@ -647,7 +631,6 @@ Describe 'LabResource' {
                 $testHostResourcePath = 'TestDrive:\Resources';
                 $fakeConfigurationData = @{ ResourcePath = $testHostResourcePath;}
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return [PSCustomObject] $fakeConfigurationData; }
-                Mock ConvertToConfigurationData -MockWith { return $configurationData; }
                 New-Item -Path "$testHostResourcePath\$testResourceId" -ItemType File -Force -ErrorAction SilentlyContinue;
 
                 { ExpandLabResource -ConfigurationData $configurationData -Name $testVM -DestinationPath $testHostResourcePath } | Should Throw;


### PR DESCRIPTION
* Fixes #89
* Adds optional -ConfigurationData switch to Remove-LabVM to support prefixed configurations.
* Deprecates ConvertToConfigurationData function in favour of the native [ArgumentToConfigurationDataTransformationAttribute()].