### PR TITLE
Fixes bug where xHyperVM\Test-TargetResource throws if a VM's VHD has…

### DIFF
--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Lability.psm1';
-    ModuleVersion = '0.9.9';
+    ModuleVersion = '0.9.10';
     GUID = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author = 'Iain Brighton';
     CompanyName = 'Virtual Engine';

--- a/Lib/VirtualMachine.ps1
+++ b/Lib/VirtualMachine.ps1
@@ -126,10 +126,13 @@ function TestLabVirtualMachine {
     process {
         $vmHyperVParams = GetVirtualMachineProperties @PSBoundParameters;
         ImportDscResource -ModuleName xHyper-V -ResourceName MSFT_xVMHyperV -Prefix VM;
-        if (-not (TestDscResource -ResourceName VM -Parameters $vmHyperVParams -ErrorAction SilentlyContinue)) {
+        try {
+            ## xVMHyperV\Test-TargetResource throws if the VHD doesn't exist?
+            return (TestDscResource -ResourceName VM -Parameters $vmHyperVParams -ErrorAction SilentlyContinue);
+        }
+        catch {
             return $false;
         }
-        return $true;
     } #end process
 } #end function TestLabVirtualMachine
 

--- a/Readme.md
+++ b/Readme.md
@@ -78,6 +78,10 @@ PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jef
 
 ## Versions
 
+### v0.9.10
+
+* Fixes bug where xHyperVM\Test-TargetResource throws if a VM's VHD has not been created.
+
 ### v0.9.9
 
 * Removes boot delay in Stop-Lab.

--- a/Tests/Lib/VirtualMachine.Tests.ps1
+++ b/Tests/Lib/VirtualMachine.Tests.ps1
@@ -176,7 +176,7 @@ Describe 'VirtualMachine' {
 
             It 'Returns false when error is thrown' {
                 Mock ImportDscResource -MockWith { }
-                Mock TestDscResource -MockWith { Write-Error 'Something went wrong' }
+                Mock TestDscResource -MockWith { throw 'Vhd not found' }
 
                 TestLabVirtualMachine @testLabVirtualMachineParams | Should Be $false;
             }


### PR DESCRIPTION
… not been created