### PR TITLE
Fixes hard-coded '\Program Files\' directory when enumerating modules

### DIFF
--- a/Lib/Module.ps1
+++ b/Lib/Module.ps1
@@ -11,8 +11,10 @@ function GetModule {
     )
     process {
         WriteVerbose -Message ($localized.LocatingModule -f $Name);
-        ## Only return modules in the C:\Program Files\WindowsPowerShell\Modules location, ignore other $env:PSModulePaths
-        $module = Get-Module -Name $Name -ListAvailable -Verbose:$false | Where-Object Path -match '\\Program Files\\WindowsPowerShell\\Modules';
+        ## Only return modules in the %ProgramFiles%\WindowsPowerShell\Modules location, ignore other $env:PSModulePaths
+        $programFiles = [System.Environment]::GetFolderPath('ProgramFiles');
+        $modulesPath = ('{0}\WindowsPowerShell\Modules' -f $programFiles).Replace('\','\\');
+        $module = Get-Module -Name $Name -ListAvailable -Verbose:$false | Where-Object Path -match $modulesPath;
         if (-not $module) {
             WriteVerbose -Message ($localized.ModuleNotFound -f $Name);
         }

--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,7 @@ PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jef
 * Adds Server 2016 Technical Preview 5 media.
 * Fixes bug in Import-LabHostConfiguration where VM defaults contains reference to custom media.
 * Fixes long local module enumeration times on build 14295 and later.
+* Fixes hard-coded '\Program Files\' directory when enumerating modules to resolve localisation issues.
 
 ### v0.9.10
 

--- a/Src/LabVMDiskFile.ps1
+++ b/Src/LabVMDiskFile.ps1
@@ -36,11 +36,11 @@ function SetLabVMDiskResource {
         [System.Collections.Hashtable]
         [Microsoft.PowerShell.DesiredStateConfiguration.ArgumentToConfigurationDataTransformationAttribute()]
         $ConfigurationData,
-        
+
         ## Lab VM/Node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $NodeName,
-        
+
         ## Prefixed/suffixed lab VM/Node name
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.String] $DisplayName
@@ -78,21 +78,21 @@ function SetLabVMDiskFile {
         ## Lab VM/Node name
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.String] $Name,
-        
+
         ## Lab VM/Node configuration data
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.Collections.Hashtable] $NodeData,
-        
+
         ## Local administrator password of the VM
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $Credential,
-        
+
         ## Lab VM/Node DSC .mof and .meta.mof configuration files
         [Parameter(ValueFromPipelineByPropertyName)]
         [System.String] $Path,
-        
+
         ## Custom bootstrap script
         [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
         [System.String] $CustomBootstrap,
@@ -110,7 +110,9 @@ function SetLabVMDiskFile {
         WriteVerbose ($localized.MountingDiskImage -f $VhdPath);
         $vhd = Mount-Vhd -Path $vhdPath -Passthru;
         [ref] $null = Get-PSDrive;
-        $vhdDriveLetter = Get-Partition -DiskNumber $vhd.DiskNumber | Where-Object DriveLetter | Select-Object -Last 1 -ExpandProperty DriveLetter;
+        $vhdDriveLetter = Get-Partition -DiskNumber $vhd.DiskNumber |
+                            Where-Object DriveLetter |
+                                Select-Object -Last 1 -ExpandProperty DriveLetter;
         Start-Service -Name 'ShellHWDetection';
 
         ## Create Unattend.xml
@@ -129,6 +131,7 @@ function SetLabVMDiskFile {
         if ($NodeData.CustomData.ProductKey) {
             $newUnattendXmlParams['ProductKey'] = $NodeData.CustomData.ProductKey;
         }
+        ## TODO: We probably need to be localise the \Windows\ and \Program Files\ directories?
         $unattendXmlPath = '{0}:\Windows\System32\Sysprep\Unattend.xml' -f $vhdDriveLetter;
         WriteVerbose ($localized.AddingUnattendXmlFile -f $unattendXmlPath);
         [ref] $null = SetUnattendXml @newUnattendXmlParams -Path $unattendXmlPath;
@@ -145,7 +148,7 @@ function SetLabVMDiskFile {
         else {
             SetBootStrap -Path $bootStrapPath -CoreCLR:$CoreCLR;
         }
-        
+
         $setupCompleteCmdPath = '{0}:\Windows\Setup\Scripts' -f $vhdDriveLetter;
         WriteVerbose ($localized.AddingSetupCompleteCmdFile -f $setupCompleteCmdPath);
         SetSetupCompleteCmd -Path $setupCompleteCmdPath -CoreCLR:$CoreCLR;


### PR DESCRIPTION
Fixes hard-coded '\Program Files\' directory when enumerating modules to resolve host localisation issues