### PR TITLE
Iterate through all switches when running Test-LabVM

### DIFF
--- a/Src/LabVM.ps1
+++ b/Src/LabVM.ps1
@@ -165,8 +165,10 @@ function Test-LabVM {
             else {
                 ## No point testing switch, vhdx and VM if the image isn't available
                 WriteVerbose ($localized.TestingVMConfiguration -f 'Virtual Switch', $node.SwitchName);
-                if (-not (TestLabSwitch -Name $node.SwitchName -ConfigurationData $ConfigurationData)) {
-                    $isNodeCompliant = $false;
+                foreach ($switchName in $node.SwitchName) {
+                    if (-not (TestLabSwitch -Name $switchName -ConfigurationData $ConfigurationData)) {
+                        $isNodeCompliant = $false;
+                    }
                 }
 
                 WriteVerbose ($localized.TestingVMConfiguration -f 'VHDX', $node.Media);


### PR DESCRIPTION
Hey,

I've been having an issue when defining multiple virtual switches in my config file as the switches aren't iterated through, and therefore Test-LabVM is trying to validate against the actual array.

The error I was getting was:
```powershell
Testing Virtual Switch configuration 'System.Object[]'.
Test-LabVM : Cannot process argument transformation on parameter 'Name'. Cannot convert 
value to type System.String.
At C:\Program Files\WindowsPowerShell\Modules\Lability\Src\LabConfiguration.ps1:40 char:32
+ ... onfigured = Test-LabVM -Name $node.NodeName -ConfigurationData $Confi ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-LabVM], ParameterBindingArgumentTran 
   sformationException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,Test-LabVM
```

I must admit, I don't really know how to use git in a team environment (I basically only ever push/pull my own stuff), so I apologies if there are conflicts or it doesn't fit the code standards.

If the pull request is garbage, I'd appreciate if somebody could look over what i'm trying to achieve and implement it themself :)

Cheers!