### PR TITLE
Releasing 0.9.11

### DIFF
--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Lability.psm1';
-    ModuleVersion = '0.9.10';
+    ModuleVersion = '0.9.11';
     GUID = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author = 'Iain Brighton';
     CompanyName = 'Virtual Engine';

--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,8 @@ PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jef
 
 ### Unreleased
 
+### v0.9.11
+
 * Fixes bug in custom media enumeration in Start-LabConfiguration (#97).
 * Removes importing module warnings when enumerating local module availability.
 * Fixes bug when invoking lab deployments with PSake (#104).


### PR DESCRIPTION
* Fixes bug in custom media enumeration in Start-LabConfiguration (#97).
* Removes importing module warnings when enumerating local module availability.
* Fixes bug when invoking lab deployments with PSake (#104).
* Adds Server 2016 Technical Preview 5 media.
* Fixes bug in Import-LabHostConfiguration where VM defaults contains reference to custom media.
* Fixes long local module enumeration times on build 14295 and later.
* Fixes hard-coded '\Program Files\' directory when enumerating modules to resolve localisation issues.
* Tests computer name for validity before creating a virtual machine (#109).