### PR TITLE
Adds output formatting

### DIFF
--- a/Lability.Format.ps1xml
+++ b/Lability.Format.ps1xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+    <ViewDefinitions>
+        <View>
+            <Name>VirtualEngine.Lability.Media</Name>
+            <ViewSelectedBy>
+                <TypeName>VirtualEngine.Lability.Media</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Arch.</Label>
+                        <Alignment>right</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Media.</Label>
+                        <Alignment>right</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Id</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Architecture</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>MediaType</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Description</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
+            <Name>VirtualEngine.Lability.Image</Name>
+            <ViewSelectedBy>
+                <TypeName>VirtualEngine.Lability.Image</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Alignment>right</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Alignment>right</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Id</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Generation</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Size</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>ImagePath</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -7,6 +7,7 @@
     Copyright = '(c) 2016 Virtual Engine Limited. All rights reserved.';
     Description = 'The Lability module contains cmdlets for provisioning Hyper-V test lab and development environments.';
     PowerShellVersion = '4.0';
+    FormatsToProcess = @('Lability.Format.ps1xml');
     FunctionsToExport = @('Start-Lab', 'Stop-Lab', 'Reset-Lab', 'Checkpoint-Lab', 'Restore-Lab','Test-LabConfiguration',
         'Start-LabConfiguration', 'Remove-LabConfiguration', 'Get-LabHostConfiguration', 'Test-LabHostConfiguration', 'Start-LabHostConfiguration',
         'Reset-LabHostDefault', 'Get-LabHostDefault', 'Set-LabHostDefault', 'Get-LabImage', 'Test-LabImage', 'New-LabImage', 'Get-LabMedia',

--- a/Lib/BootStrap.ps1
+++ b/Lib/BootStrap.ps1
@@ -10,6 +10,7 @@ function NewBootStrap {
         [System.Management.Automation.SwitchParameter] $CoreCLR
     )
     process {
+
         $coreCLRScriptBlock = {
 ## Lability CoreCLR DSC Bootstrap
 $VerbosePreference = 'Continue';
@@ -23,18 +24,9 @@ if (Test-Path -Path "$env:SystemDrive\BootStrap\localhost.meta.mof") {
 }
 
 if (Test-Path -Path "$env:SystemDrive\BootStrap\localhost.mof") {
-    while ($true) {
-        ## Replay the configuration until the LCM bloody-well takes it!
-        try {
-            Start-DscConfiguration -Path "$env:SystemDrive\Bootstrap\" -Force -Wait -Verbose -ErrorAction Stop;
-            break;
-        }
-        catch {
-            Write-Error -Message $_;
-            Start-Sleep -Seconds 5;
-        }
-    } #end while
+    Start-DscConfiguration -Path "$env:SystemDrive\Bootstrap\" -Force -Wait -Verbose -ErrorAction Stop;
 } #end if localhost.mof
+
 } #end CoreCLR bootstrap scriptblock
 
         $scriptBlock = {
@@ -59,28 +51,35 @@ if (Test-Path -Path "$env:SystemDrive\BootStrap\localhost.meta.mof") {
 
 $localhostMofPath = "$env:SystemDrive\BootStrap\localhost.mof";
 if (Test-Path -Path $localhostMofPath) {
+
     if ($PSVersionTable.PSVersion.Major -eq 4) {
+
         ## Convert the .mof to v4 compatible - credit to Mike Robbins
         ## http://mikefrobbins.com/2014/10/30/powershell-desired-state-configuration-error-undefined-property-configurationname/
         $mof = Get-Content -Path $localhostMofPath;
         $mof -replace '^\sName=.*;$|^\sConfigurationName\s=.*;$' | Set-Content -Path $localhostMofPath -Encoding Unicode -Force;
     }
     while ($true) {
-        ## Replay the configuration until the LCM bloody-well takes it!
+        ## Replay the configuration until the LCM bloody-well takes it (more of a WMF 4 thing)!
         try {
+
             if (Test-Path -Path "$env:SystemRoot\System32\Configuration\Pending.mof") {
+
                 Start-DscConfiguration -UseExisting -Force -Wait -Verbose -ErrorAction Stop;
                 break;
             }
             else {
+
                 Start-DscConfiguration -Path "$env:SystemDrive\Bootstrap\" -Force -Wait -Verbose -ErrorAction Stop;
                 break;
             }
         }
         catch {
+
             Write-Error -Message $_;
             ## SIGH. Try restarting WMI..
             if (-not ($interation % 10)) {
+
                 ## SIGH. Try removing the configuration and restarting WMI..
                 Remove-DscConfigurationDocument -Stage Current,Pending,Previous -Force;
                 Restart-Service -Name Winmgmt -Force;
@@ -95,13 +94,16 @@ Stop-Transcript;
 } #end bootstrap scriptblock
 
         if ($CoreCLR) {
+
             return $coreCLRScriptBlock;
         }
         else {
+
             return $scriptBlock;
         }
     } #end process
 } #end function NewBootStrap
+
 
 function SetSetupCompleteCmd {
 <#
@@ -112,7 +114,8 @@ function SetSetupCompleteCmd {
     [OutputType([System.Management.Automation.ScriptBlock])]
     param (
         ## Destination SetupComplete.cmd directory path.
-        [Parameter(Mandatory, ValueFromPipeline)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Path,
 
         ## Is a CoreCLR VM. The bootstrapping via Powershell.exe in the CoreCLR doesn't work in its current format, i.e. with Nano Server
@@ -120,9 +123,11 @@ function SetSetupCompleteCmd {
         [System.Management.Automation.SwitchParameter] $CoreCLR
     )
     process {
+
         [ref] $null = NewDirectory -Path $Path;
         $setupCompletePath = Join-Path -Path $Path -ChildPath 'SetupComplete.cmd';
         if ($CoreCLR) {
+
             WriteVerbose -Message $localized.UsingCoreCLRSetupComplete;
             $setupCompleteCmd = @"
 schtasks /create /tn "BootStrap" /tr "cmd.exe /c """Powershell.exe -Command %SYSTEMDRIVE%\BootStrap\BootStrap.ps1""" > %SYSTEMDRIVE%\BootStrap\BootStrap.log" /sc "Once" /sd "01/01/2099" /st "00:00" /ru "System"
@@ -130,12 +135,15 @@ schtasks /run /tn "BootStrap"
 "@
         }
         else {
+
             WriteVerbose -Message $localized.UsingDefaultSetupComplete;
             $setupCompleteCmd = 'Powershell.exe -NoProfile -ExecutionPolicy Bypass -NonInteractive -File "%SYSTEMDRIVE%\BootStrap\BootStrap.ps1"';
         }
         Set-Content -Path $setupCompletePath -Value $setupCompleteCmd -Encoding Ascii -Force;
+
     } #end process
 } #end function SetSetupCompleteCmd
+
 
 function SetBootStrap {
 <#
@@ -149,7 +157,8 @@ function SetBootStrap {
         [System.String] $Path,
 
         ## Custom bootstrap script
-        [Parameter(ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $CustomBootStrap,
 
         ## Is a CoreCLR VM. The PowerShell switches are different in the CoreCLR, i.e. Nano Server
@@ -157,15 +166,19 @@ function SetBootStrap {
         [System.Management.Automation.SwitchParameter] $CoreCLR
     )
     process {
+
         [ref] $null = NewDirectory -Path $Path;
         $bootStrapPath = Join-Path -Path $Path -ChildPath 'BootStrap.ps1';
         $bootStrap = (NewBootStrap -CoreCLR:$CoreCLR).ToString();
         if ($CustomBootStrap) {
+
             $bootStrap = $bootStrap -replace '<#CustomBootStrapInjectionPoint#>', $CustomBootStrap;
         }
         Set-Content -Path $bootStrapPath -Value $bootStrap -Encoding UTF8 -Force;
+
     } #end process
 } #end function SetBootStrap
+
 
 function ResolveCustomBootStrap {
 <#
@@ -181,27 +194,35 @@ function ResolveCustomBootStrap {
         [System.String] $CustomBootstrapOrder,
 
         ## Node/configuration custom bootstrap script
-        [Parameter(ValueFromPipelineByPropertyName)] [AllowNull()]
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [AllowNull()]
         [System.String] $ConfigurationCustomBootStrap,
 
         ## Media custom bootstrap script
-        [Parameter(ValueFromPipelineByPropertyName)] [AllowNull()]
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [AllowNull()]
         [System.String[]] $MediaCustomBootStrap
     )
     begin {
+
         if ([System.String]::IsNullOrWhiteSpace($ConfigurationCustomBootStrap)) {
+
             $ConfigurationCustomBootStrap = "";
         }
         ## Convert the string[] into a multi-line string
         if ($MediaCustomBootstrap) {
+
             $mediaBootstrap = [System.String]::Join("`r`n", $MediaCustomBootStrap);
         }
         else {
+
             $mediaBootstrap = "";
         }
     } #end begin
     process {
+
         switch ($CustomBootstrapOrder) {
+
             'ConfigurationFirst' {
                 $bootStrap = "{0}`r`n{1}" -f $ConfigurationCustomBootStrap, $mediaBootstrap;
             }
@@ -218,6 +239,8 @@ function ResolveCustomBootStrap {
                 #Disabled
             }
         } #end switch
+
         return $bootStrap;
+
     } #end process
 } #end function ResolveCustomBootStrap

--- a/Lib/DiskImage.ps1
+++ b/Lib/DiskImage.ps1
@@ -7,22 +7,27 @@ function GetDiskImageDriveLetter {
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [System.Object] $DiskImage,
-        
-        [Parameter(Mandatory)] [ValidateSet('Basic','System','IFS')]
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Basic','System','IFS')]
         [System.String] $PartitionType
     )
     process {
+
         # Microsoft.Vhd.PowerShell.VirtualHardDisk
         $driveLetter = Get-Partition -DiskNumber $DiskImage.DiskNumber |
             Where-Object Type -eq $PartitionType |
                 Where-Object DriveLetter |
                     Select-Object -Last 1 -ExpandProperty DriveLetter;
+
         if (-not $driveLetter) {
+
             throw ($localized.CannotLocateDiskImageLetter -f $DiskImage.Path);
         }
         return $driveLetter;
     }
 } #end function GetDiskImageDriveLetter
+
 
 function NewDiskImageMbr {
 <#
@@ -32,22 +37,28 @@ function NewDiskImageMbr {
     [CmdletBinding()]
     param (
         ## Mounted VHD(X) Operating System disk image
-        [Parameter(Mandatory)] [ValidateNotNull()]
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
         [System.Object] $Vhd # Microsoft.Vhd.PowerShell.VirtualHardDisk
     )
     process {
+
         ## Temporarily disable Windows Explorer popup disk initialization and format notifications
         ## http://blogs.technet.com/b/heyscriptingguy/archive/2013/05/29/use-powershell-to-initialize-raw-disks-and-partition-and-format-volumes.aspx
         Stop-Service -Name 'ShellHWDetection' -Force -ErrorAction Ignore;
-        WriteVerbose ($localized.CreatingDiskPartition -f 'OS');
+
+        WriteVerbose ($localized.CreatingDiskPartition -f 'Windows');
         $osPartition = New-Partition -DiskNumber $Vhd.DiskNumber -UseMaximumSize -MbrType IFS -IsActive |
             Add-PartitionAccessPath -AssignDriveLetter -PassThru |
                 Get-Partition;
-        WriteVerbose ($localized.FormattingDiskPartition -f 'OS');
+        WriteVerbose ($localized.FormattingDiskPartition -f 'Windows');
         $osVolume = Format-Volume -Partition $osPartition -FileSystem NTFS -Force -Confirm:$false;
+
         Start-Service -Name 'ShellHWDetection';
+
     } #end proces
 } #end function NewDiskImageMbr
+
 
 function NewDiskPartFat32Partition {
 <#
@@ -58,7 +69,7 @@ function NewDiskPartFat32Partition {
     param (
         [Parameter(Mandatory)]
         [System.Int32] $DiskNumber,
-        
+
         [Parameter(Mandatory)]
         [System.Int32] $PartitionNumber
     )
@@ -71,6 +82,7 @@ format fs=fat32 label="System"
     }
 }
 
+
 function NewDiskImageGpt {
 <#
     .SYNOPSIS
@@ -79,24 +91,34 @@ function NewDiskImageGpt {
     [CmdletBinding()]
     param (
         ## Mounted VHD(X) Operating System disk image
-        [Parameter(Mandatory)] [ValidateNotNull()]
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
         [System.Object] $Vhd # Microsoft.Vhd.PowerShell.VirtualHardDisk
     )
     process {
+
         ## Temporarily disable Windows Explorer popup disk initialization and format notifications
         ## http://blogs.technet.com/b/heyscriptingguy/archive/2013/05/29/use-powershell-to-initialize-raw-disks-and-partition-and-format-volumes.aspx
         Stop-Service -Name 'ShellHWDetection' -Force -ErrorAction Ignore;
-        WriteVerbose ($localized.CreatingDiskPartition -f 'System');
-        $systemPartition = New-Partition -DiskNumber $Vhd.DiskNumber -Size 250MB -GptType '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}' -AssignDriveLetter;
-        WriteVerbose ($localized.FormattingDiskPartition -f 'System');
-        NewDiskPartFat32Partition -DiskNumber $Vhd.DiskNumber -PartitionNumber $systemPartition.PartitionNumber;
-        WriteVerbose ($localized.CreatingDiskPartition -f 'OS');
+
+        WriteVerbose ($localized.CreatingDiskPartition -f 'EFI');
+        $efiPartition = New-Partition -DiskNumber $Vhd.DiskNumber -Size 250MB -GptType '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}' -AssignDriveLetter;
+        WriteVerbose ($localized.FormattingDiskPartition -f 'EFI');
+        NewDiskPartFat32Partition -DiskNumber $Vhd.DiskNumber -PartitionNumber $efiPartition.PartitionNumber;
+
+        WriteVerbose ($localized.CreatingDiskPartition -f 'MSR');
+        $msrPartition = New-Partition -DiskNumber $Vhd.DiskNumber -Size 128MB -GptType '{e3c9e316-0b5c-4db8-817d-f92df00215ae}';
+
+        WriteVerbose ($localized.CreatingDiskPartition -f 'Windows');
         $osPartition = New-Partition -DiskNumber $Vhd.DiskNumber -UseMaximumSize -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}' -AssignDriveLetter;
-        WriteVerbose ($localized.FormattingDiskPartition -f 'OS');
+        WriteVerbose ($localized.FormattingDiskPartition -f 'Windows');
         $osVolume = Format-Volume -Partition $osPartition -FileSystem NTFS -Force -Confirm:$false;
+
         Start-Service -Name 'ShellHWDetection';
+
     } #end process
 } #end function NewDiskImageGpt
+
 
 function NewDiskImage {
 <#
@@ -106,36 +128,43 @@ function NewDiskImage {
     [CmdletBinding()]
     param (
         ## VHD/x file path
-        [Parameter(Mandatory)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Path,
-        
+
         ## Disk image partition scheme
-        [Parameter(Mandatory)] [ValidateSet('MBR','GPT')]
+        [Parameter(Mandatory)]
+        [ValidateSet('MBR','GPT')]
         [System.String] $PartitionStyle,
-        
+
         ## Disk image size in bytes
         [Parameter()]
         [System.UInt64] $Size = 127GB,
-        
+
         ## Overwrite/recreate existing disk image
         [Parameter()]
         [System.Management.Automation.SwitchParameter] $Force,
-        
+
         ## Do not dismount the VHD/x and return a reference
         [Parameter()]
         [System.Management.Automation.SwitchParameter] $Passthru
     )
     begin {
+
         if ((Test-Path -Path $Path -PathType Leaf) -and (-not $Force)) {
+
             throw ($localized.ImageAlreadyExistsError -f $Path);
         }
         elseif ((Test-Path -Path $Path -PathType Leaf) -and ($Force)) {
+
             Dismount-VHD -Path $Path -ErrorAction Stop;
             WriteVerbose ($localized.RemovingDiskImage -f $Path);
             Remove-Item -Path $Path -Force -ErrorAction Stop;
         }
+
     } #end begin
     process {
+
         WriteVerbose ($localized.CreatingDiskImage -f $Path);
         $vhd = New-Vhd -Path $Path -Dynamic -SizeBytes $Size;
         WriteVerbose ($localized.MountingDiskImage -f $Path);
@@ -152,10 +181,18 @@ function NewDiskImage {
             }
         }
 
-        if ($Passthru) { return $vhdMount; }
-        else { Dismount-VHD -Path $Path; }
+        if ($Passthru) {
+
+            return $vhdMount;
+        }
+        else {
+
+            Dismount-VHD -Path $Path;
+        }
+
     } #end process
 } #end function NewDiskImage
+
 
 function SetDiskImageBootVolumeMbr {
 <#
@@ -165,10 +202,12 @@ function SetDiskImageBootVolumeMbr {
     [CmdletBinding()]
     param (
         ## Mounted VHD(X) Operating System disk image
-        [Parameter(Mandatory)] [ValidateNotNull()]
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
         [System.Object] $Vhd # Microsoft.Vhd.PowerShell.VirtualHardDisk
     )
     process {
+
         $bcdBootExe = 'bcdboot.exe';
         $bcdEditExe = 'bcdedit.exe';
         $imageName = [System.IO.Path]::GetFileNameWithoutExtension($Vhd.Path);
@@ -200,8 +239,10 @@ function SetDiskImageBootVolumeMbr {
             '/set {default} osdevice locate'
         );
         InvokeExecutable -Path $bcdEditExe -Arguments $defaultOsDeviceArgs -LogName ('{0}-DefaultOsDevice.log' -f $imageName);
+
     } #end process
 } #end function
+
 
 function SetDiskImageBootVolumeGpt {
 <#
@@ -211,10 +252,12 @@ function SetDiskImageBootVolumeGpt {
     [CmdletBinding()]
     param (
         ## Mounted VHD(X) Operating System disk image
-        [Parameter(Mandatory)] [ValidateNotNull()]
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
         [System.Object] $Vhd # Microsoft.Vhd.PowerShell.VirtualHardDisk
     )
     process {
+
         $bcdBootExe = 'bcdboot.exe';
         $imageName = [System.IO.Path]::GetFileNameWithoutExtension($Vhd.Path);
 
@@ -231,8 +274,10 @@ function SetDiskImageBootVolumeGpt {
         ## Clean up and remove drive access path
         Remove-PSDrive -Name $osPartitionDriveLetter -PSProvider FileSystem -ErrorAction Ignore;
         [ref] $null = Get-PSDrive;
+
     } #end process
 } #end function
+
 
 function SetDiskImageBootVolume {
 <#
@@ -242,14 +287,17 @@ function SetDiskImageBootVolume {
     [CmdletBinding()]
     param (
         ## Mounted VHD(X) Operating System disk image
-        [Parameter(Mandatory)] [ValidateNotNull()]
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
         [System.Object] $Vhd, # Microsoft.Vhd.PowerShell.VirtualHardDisk
-        
+
         ## Disk image partition scheme
-        [Parameter(Mandatory)] [ValidateSet('MBR','GPT')]
+        [Parameter(Mandatory)]
+        [ValidateSet('MBR','GPT')]
         [System.String] $PartitionStyle
     )
     process {
+
         switch ($PartitionStyle) {
             'MBR' {
                 SetDiskImageBootVolumeMbr -Vhd $Vhd;
@@ -260,8 +308,10 @@ function SetDiskImageBootVolume {
                 break;
             }
         } #end switch
+
     } #end process
 } #end function SetDiskImageBootVolume
+
 
 function AddDiskImageHotfix {
 <#
@@ -270,31 +320,44 @@ function AddDiskImageHotfix {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory, ValueFromPipeline)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Id,
-        
+
         ## Mounted VHD(X) Operating System disk image
-        [Parameter(Mandatory)] [ValidateNotNull()]
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
         [System.Object] $Vhd, # Microsoft.Vhd.PowerShell.VirtualHardDisk
-        
+
         ## Disk image partition scheme
-        [Parameter(Mandatory)] [ValidateSet('MBR','GPT')]
+        [Parameter(Mandatory)]
+        [ValidateSet('MBR','GPT')]
         [System.String] $PartitionStyle
     )
     process {
-        if ($PartitionStyle -eq 'MBR') { $partitionType = 'IFS'; }
-        elseif ($PartitionStyle -eq 'GPT') { $partitionType = 'Basic'; }
+
+        if ($PartitionStyle -eq 'MBR') {
+
+            $partitionType = 'IFS';
+        }
+        elseif ($PartitionStyle -eq 'GPT') {
+
+            $partitionType = 'Basic';
+        }
         $vhdDriveLetter = GetDiskImageDriveLetter -DiskImage $Vhd -PartitionType $partitionType;
         $media = Get-LabMedia -Id $Id;
-        
+
         foreach ($hotfix in $media.Hotfixes) {
+
             $hotfixFileInfo = InvokeLabMediaHotfixDownload -Id $hotfix.Id -Uri $hotfix.Uri;
             $packageName = [System.IO.Path]::GetFileNameWithoutExtension($hotfixFileInfo.FullName);
 
             AddDiskImagePackage -Name $packageName -Path $hotfixFileInfo.FullName -DestinationPath $vhdDriveLetter;
         }
+
     } #end process
 } #end function AddDiskImageHotfix
+
 
 function AddDiskImagePackage {
 <#
@@ -308,27 +371,34 @@ function AddDiskImagePackage {
     [CmdletBinding()]
     param (
         ## Package name (used for logging)
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Name,
 
         ## File path to the package (.cab) file
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Path,
 
         ## Destination operating system path (mounted VHD), i.e. G:\
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $DestinationPath
     )
     begin {
+
         ## We just want the drive letter
         if ($DestinationPath.Length -gt 1) {
+
             $DestinationPath = $DestinationPath.Substring(0,1);
         }
+
     }
     process {
+
         $logPath = '{0}:\Windows\Logs\{1}' -f $DestinationPath, $labDefaults.ModuleName;
         [ref] $null = NewDirectory -Path $logPath -Verbose:$false;
-        
+
         WriteVerbose ($localized.AddingImagePackage -f $Name, $DestinationPath);
         $addWindowsPackageParams = @{
             PackagePath = $Path;
@@ -337,5 +407,6 @@ function AddDiskImagePackage {
             LogLevel = 'Errors';
         }
         [ref] $null = Add-WindowsPackage @addWindowsPackageParams -Verbose:$false;
+
     } #end process
 } #end function AddDiskImagePackage

--- a/Readme.md
+++ b/Readme.md
@@ -89,6 +89,7 @@ Other generous members of the community have written some comprehensive guides t
 * Removes local Administrator password from verbose output (#140)
 * Reinstates the xDhcpServerOption 'Router' parameter in example TestLabGuide.ps1
 * Fixes bug in 'IsLocal' resource when combined with a custom 'DestinationPath' location
+* Adds output formatting to lab images and media
 
 ### v0.10.0
 

--- a/Readme.md
+++ b/Readme.md
@@ -73,10 +73,22 @@ will:
  * Create differencing VHDX for each VM
  * Inject a dynamically created Unattend.xml file into the differencing VHDX
 
+### Community Resources
 A brief introduction to the __VirtualEngineLab__ module presented at the European
 PowerShell Summit 2015 can be found __[here](https://www.youtube.com/watch?v=jefhLaJsG3E "Man vs TestLab")__.
+Other generous members of the community have written some comprehensive guides to compliment the built-in documentation – thank you!
+
+* [Building A Lab using Hyper-V and Lability](https://blog.kilasuit.org/2016/04/13/building-a-lab-using-hyper-v-and-lability-the-end-to-end-example/) via @kilasuit
+* [The Ultimate Hyper-V Lab Tool](http://www.absolutejam.co.uk/posts/lability-the-ultimate-hyper-v-lab-tool/) via @absolutejam
+* [Create Your Virtual Lab Environment with Lability How-To](http://blog.mscloud.guru/2016/09/17/create-your-virtual-lab-environment-with-lability-howto/) via @Naboo2604
 
 ## Versions
+
+### Unreleased
+
+* Removes local Administrator password from verbose output (#140)
+* Reinstates the xDhcpServerOption 'Router' parameter in example TestLabGuide.ps1
+* Fixes bug in 'IsLocal' resource when combined with a custom 'DestinationPath' location
 
 ### v0.10.0
 

--- a/Resources.psd1
+++ b/Resources.psd1
@@ -93,7 +93,7 @@ ConvertFrom-StringData -StringData @'
     ResolvedDestinationPath         = Resolved Zip destination path '{0}'.
     ResolvedSourcePath              = Resolved Zip source path '{0}'.
     EnterLocalAdministratorPassword = Enter the virtual machines' local administrator password.
-    SettingAdministratorPassword    = Setting local administrator password to '{0}'.
+    SettingAdministratorPassword    = Setting local administrator password.
     DownloadingAllRequiredMedia     = No media Id specified; downloading all required media.
     DownloadingAllRequiredHotfixes  = Downloading all required hotfixes.
     DownloadingAllDefinedResources  = No resource Id specified; downloading all defined resources.

--- a/Src/LabImage.ps1
+++ b/Src/LabImage.ps1
@@ -21,7 +21,8 @@ function Get-LabImage {
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSCustomObject])]
     param (
-        [Parameter(ValueFromPipeline,ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Id,
 
         ## Lab DSC configuration data
@@ -31,15 +32,19 @@ function Get-LabImage {
         $ConfigurationData
     )
     process {
+
         $hostDefaults = GetConfigurationData -Configuration Host;
         $parentVhdPath = ResolvePathEx -Path $hostDefaults.ParentVhdPath;
 
         if ($PSBoundParameters.ContainsKey('Id')) {
+
             ## We have an Id. so resolve that
             try {
+
                 $labMedia = ResolveLabMedia @PSBoundParameters;
             }
             catch {
+
                 $labMedia = $null;
             }
         }
@@ -49,13 +54,16 @@ function Get-LabImage {
         }
 
         foreach ($media in $labMedia) {
+
             $differencingVhdPath = '{0}.vhdx' -f $media.Id;
             if ($media.MediaType -eq 'VHD') {
+
                 $differencingVhdPath = $media.Filename;
             }
 
             $imagePath = Join-Path -Path $parentVhdPath -ChildPath $differencingVhdPath;
             if (Test-Path -Path $imagePath -PathType Leaf) {
+
                 $imageFileInfo = Get-Item -Path $imagePath;
                 $diskImage = Get-DiskImage -ImagePath $imageFileInfo.FullName;
                 $labImage = [PSCustomObject] @{
@@ -68,11 +76,16 @@ function Get-LabImage {
                     Size = $diskImage.Size;
                     Generation = ($imagePath.Split('.')[-1]).ToUpper();
                 }
+
+                $labImage.PSObject.TypeNames.Insert(0, 'VirtualEngine.Lability.Image');
                 Write-Output -InputObject $labImage;
             }
+
         } #end foreach media
+
     } #end process
 } #end function Get-LabImage
+
 
 function Test-LabImage {
 <#
@@ -95,7 +108,8 @@ function Test-LabImage {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param (
-        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Id,
 
         ## Lab DSC configuration data
@@ -105,14 +119,19 @@ function Test-LabImage {
         $ConfigurationData
     )
     process {
+
         if (Get-LabImage @PSBoundParameters) {
+
             return $true;
         }
         else {
+
             return $false;
         }
+
     } #end process
 } #end function Test-LabImage
+
 
 function New-LabImage {
 <#
@@ -143,10 +162,11 @@ function New-LabImage {
         Get-LabImage
 #>
     [CmdletBinding(SupportsShouldProcess)]
-    [OutputType([System.IO.FileInfo])]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     param (
         ## Lab media Id
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
         [System.String] $Id,
 
         ## Lab DSC configuration data
@@ -160,17 +180,20 @@ function New-LabImage {
         [System.Management.Automation.SwitchParameter] $Force
     )
     process {
+
         ## Download media if required..
         [ref] $null = $PSBoundParameters.Remove('Force');
         [ref] $null = $PSBoundParameters.Remove('WhatIf');
         [ref] $null = $PSBoundParameters.Remove('Confirm');
 
         if ((Test-LabImage @PSBoundParameters) -and $Force) {
+
             $image = Get-LabImage @PSBoundParameters;
             WriteVerbose ($localized.RemovingDiskImage -f $image.ImagePath);
             [ref] $null = Remove-Item -Path $image.ImagePath -Force -ErrorAction Stop;
         }
         elseif (Test-LabImage @PSBoundParameters) {
+
             throw ($localized.ImageAlreadyExistsError -f $Id);
         }
 
@@ -179,27 +202,33 @@ function New-LabImage {
         $hostDefaults = GetConfigurationData -Configuration Host;
 
         if ($media.MediaType -eq 'VHD') {
+
             WriteVerbose ($localized.ImportingExistingDiskImage -f $media.Description);
             $imageName = $media.Filename;
             $imagePath = Join-Path -Path $hostDefaults.ParentVhdPath -ChildPath $imageName;
         } #end if VHD
         else {
+
             WriteVerbose ($localized.CreatingDiskImage -f $media.Description);
             $imageName = '{0}.vhdx' -f $Id;
             $imagePath = Join-Path -Path $hostDefaults.ParentVhdPath -ChildPath $imageName;
             $imageCreationFailed = $false;
 
             try {
+
                 ## Create VHDX
                 if ($media.CustomData.PartitionStyle) {
+
                     ## Custom partition style has been defined so use that
                     $partitionStyle = $media.CustomData.PartitionStyle;
                 }
                 elseif ($media.Architecture -eq 'x86') {
+
                     ## Otherwise default to MBR for x86 media
                     $partitionStyle = 'MBR';
                 }
                 else {
+
                     $partitionStyle = 'GPT';
                 }
 
@@ -218,25 +247,32 @@ function New-LabImage {
                 ## specifying an integer image index in a media's 'ImageName' property.
                 [System.Int32] $wimImageIndex = $null;
                 if ([System.Int32]::TryParse($media.ImageName, [ref] $wimImageIndex)) {
+
                     $expandWindowsImageParams['WimImageIndex'] = $wimImageIndex;
                 }
                 else {
+
                     $expandWindowsImageParams['WimImageName'] = $media.ImageName;
                 }
 
                 if ($media.CustomData.SourcePath) {
+
                     $expandWindowsImageParams['SourcePath'] = $media.CustomData.SourcePath;
                 }
                 if ($media.CustomData.WimPath) {
+
                     $expandWindowsImageParams['WimPath'] = $media.CustomData.WimPath;
                 }
                 if ($media.CustomData.WindowsOptionalFeature) {
+
                     $expandWindowsImageParams['WindowsOptionalFeature'] = $media.CustomData.WindowsOptionalFeature;
                 }
                 if ($media.CustomData.PackagePath) {
+
                     $expandWindowsImageParams['PackagePath'] = $media.CustomData.PackagePath;
                 }
                 if ($media.CustomData.Package) {
+
                     $expandWindowsImageParams['Package'] = $media.CustomData.Package;
                 }
 
@@ -247,22 +283,25 @@ function New-LabImage {
                 SetDiskImageBootVolume -Vhd $image -PartitionStyle $partitionStyle;
             }
             catch {
+
                 ## Have to ensure VHDX is dismounted before we can delete!
                 $imageCreationFailed = $true;
                 Write-Error -Message $_;
             }
             finally {
+
                 ## Dismount VHDX
                 Dismount-VHD -Path $imagePath;
             }
 
             if ($imageCreationFailed -eq $true) {
+
                 WriteWarning ($localized.RemovingIncompleteImageWarning -f $imagePath);
                 Remove-Item -Path $imagePath -Force;
             }
         } #end if ISO/WIM
 
-        return (Get-Item -Path $imagePath -ErrorAction Ignore);
+        return (Get-LabImage $PSBoundParameters);
 
     } #end process
 } #end function New-LabImage

--- a/Src/LabVMDiskFile.ps1
+++ b/Src/LabVMDiskFile.ps1
@@ -69,7 +69,7 @@ function SetLabVMDiskFileResource {
             Name = $NodeName;
             DestinationPath = $resourceDestinationPath;
         }
-        WriteVerbose ($localized.AddingVMResource -f 'VM');
+        WriteVerbose -Message ($localized.AddingVMResource -f 'VM');
         ExpandLabResource @expandLabResourceParams;
 
     } #end process
@@ -119,7 +119,7 @@ function SetLabVMDiskFileModule {
             DestinationPath = $programFilesPath;
         }
         if ($null -ne $setLabVMDiskDscModuleParams['Module']) {
-            WriteVerbose ($localized.AddingDSCResourceModules -f $programFilesPath);
+            WriteVerbose -Message ($localized.AddingDSCResourceModules -f $programFilesPath);
             SetLabVMDiskModule @setLabVMDiskDscModuleParams;
         }
 
@@ -134,7 +134,7 @@ function SetLabVMDiskFileModule {
             DestinationPath = $programFilesPath;
         }
         if ($null -ne $setLabVMDiskPowerShellModuleParams['Module']) {
-            WriteVerbose ($localized.AddingPowerShellModules -f $programFilesPath);
+            WriteVerbose -Message ($localized.AddingPowerShellModules -f $programFilesPath);
             SetLabVMDiskModule @setLabVMDiskPowerShellModuleParams;
         }
 
@@ -190,13 +190,13 @@ function SetLabVMDiskFileUnattendXml {
             RegisteredOwner = $node.RegisteredOwner;
             RegisteredOrganization = $node.RegisteredOrganization;
         }
-        WriteVerbose ($localized.SettingAdministratorPassword -f $Credential.GetNetworkCredential().Password);
+        WriteVerbose -Message $localized.SettingAdministratorPassword;
         if ($node.CustomData.ProductKey) {
             $newUnattendXmlParams['ProductKey'] = $node.CustomData.ProductKey;
         }
         ## TODO: We probably need to be localise the \Windows\ (%ProgramFiles% has been done) directory?
         $unattendXmlPath = '{0}:\Windows\System32\Sysprep\Unattend.xml' -f $VhdDriveLetter;
-        WriteVerbose ($localized.AddingUnattendXmlFile -f $unattendXmlPath);
+        WriteVerbose -Message ($localized.AddingUnattendXmlFile -f $unattendXmlPath);
         [ref] $null = SetUnattendXml @newUnattendXmlParams -Path $unattendXmlPath;
 
     } #end process
@@ -231,7 +231,7 @@ function SetLabVMDiskFileBootstrap {
     process {
 
         $bootStrapPath = '{0}:\BootStrap' -f $VhdDriveLetter;
-        WriteVerbose ($localized.AddingBootStrapFile -f $bootStrapPath);
+        WriteVerbose -Message ($localized.AddingBootStrapFile -f $bootStrapPath);
         if ($CustomBootStrap) {
             SetBootStrap -Path $bootStrapPath -CustomBootStrap $CustomBootStrap -CoreCLR:$CoreCLR;
         }
@@ -240,7 +240,7 @@ function SetLabVMDiskFileBootstrap {
         }
 
         $setupCompleteCmdPath = '{0}:\Windows\Setup\Scripts' -f $vhdDriveLetter;
-        WriteVerbose ($localized.AddingSetupCompleteCmdFile -f $setupCompleteCmdPath);
+        WriteVerbose -Message ($localized.AddingSetupCompleteCmdFile -f $setupCompleteCmdPath);
         SetSetupCompleteCmd -Path $setupCompleteCmdPath -CoreCLR:$CoreCLR;
 
     } #end process
@@ -277,18 +277,18 @@ function SetLabVMDiskFileMof {
         $mofPath = Join-Path -Path $Path -ChildPath ('{0}.mof' -f $NodeName);
 
         if (-not (Test-Path -Path $mofPath)) {
-            WriteWarning ($localized.CannotLocateMofFileError -f $mofPath);
+            WriteWarning -Message ($localized.CannotLocateMofFileError -f $mofPath);
         }
         else {
             $destinationMofPath = Join-Path -Path $bootStrapPath -ChildPath 'localhost.mof';
-            WriteVerbose ($localized.AddingDscConfiguration -f $destinationMofPath);
+            WriteVerbose -Message ($localized.AddingDscConfiguration -f $destinationMofPath);
             Copy-Item -Path $mofPath -Destination $destinationMofPath -Force -ErrorAction Stop;
         }
 
         $metaMofPath = Join-Path -Path $Path -ChildPath ('{0}.meta.mof' -f $NodeName);
         if (Test-Path -Path $metaMofPath -PathType Leaf) {
             $destinationMetaMofPath = Join-Path -Path $bootStrapPath -ChildPath 'localhost.meta.mof';
-            WriteVerbose ($localized.AddingDscConfiguration -f $destinationMetaMofPath);
+            WriteVerbose -Message ($localized.AddingDscConfiguration -f $destinationMetaMofPath);
             Copy-Item -Path $metaMofPath -Destination $destinationMetaMofPath -Force;
         }
 
@@ -330,14 +330,14 @@ function SetLabVMDiskFileCertificate {
         if (-not [System.String]::IsNullOrWhitespace($node.ClientCertificatePath)) {
             $destinationCertificatePath = Join-Path -Path $bootStrapPath -ChildPath 'LabClient.pfx';
             $expandedClientCertificatePath = [System.Environment]::ExpandEnvironmentVariables($node.ClientCertificatePath);
-            WriteVerbose ($localized.AddingCertificate -f 'Client', $destinationCertificatePath);
+            WriteVerbose -Message ($localized.AddingCertificate -f 'Client', $destinationCertificatePath);
             Copy-Item -Path $expandedClientCertificatePath -Destination $destinationCertificatePath -Force;
         }
 
         if (-not [System.String]::IsNullOrWhitespace($node.RootCertificatePath)) {
             $destinationCertificatePath = Join-Path -Path $bootStrapPath -ChildPath 'LabRoot.cer';
             $expandedRootCertificatePath = [System.Environment]::ExpandEnvironmentVariables($node.RootCertificatePath);
-            WriteVerbose ($localized.AddingCertificate -f 'Root', $destinationCertificatePath);
+            WriteVerbose -Message ($localized.AddingCertificate -f 'Root', $destinationCertificatePath);
             Copy-Item -Path $expandedRootCertificatePath -Destination $destinationCertificatePath -Force;
         }
 
@@ -394,7 +394,7 @@ function SetLabVMDiskFile {
         $node = ResolveLabVMProperties -NodeName $NodeName -ConfigurationData $ConfigurationData -ErrorAction Stop;
         $vhdPath = ResolveLabVMDiskPath -Name $node.NodeDisplayName;
 
-        WriteVerbose ($localized.MountingDiskImage -f $VhdPath);
+        WriteVerbose -Message ($localized.MountingDiskImage -f $VhdPath);
         $vhd = Mount-Vhd -Path $vhdPath -Passthru;
         [ref] $null = Get-PSDrive;
         $vhdDriveLetter = Get-Partition -DiskNumber $vhd.DiskNumber |
@@ -409,7 +409,7 @@ function SetLabVMDiskFile {
         SetLabVMDiskFileCertificate @PSBoundParameters -VhdDriveLetter $vhdDriveLetter;
         SetLabVMDiskFileModule @PSBoundParameters -VhdDriveLetter $vhdDriveLetter;
 
-        WriteVerbose ($localized.DismountingDiskImage -f $VhdPath);
+        WriteVerbose -Message ($localized.DismountingDiskImage -f $VhdPath);
         Dismount-Vhd -Path $VhdPath;
 
     } #end process


### PR DESCRIPTION
* Removes local Administrator password from verbose output (#140)
* Reinstates the xDhcpServerOption 'Router' parameter in example TestLabGuide.ps1
* Fixes bug in 'IsLocal' resource when combined with a custom 'DestinationPath' location
* Adds output formatting to lab images and media