### PR TITLE
Releasing 0.10.2

### DIFF
--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Lability.psm1';
-    ModuleVersion = '0.10.1';
+    ModuleVersion = '0.10.2';
     GUID = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author = 'Iain Brighton';
     CompanyName = 'Virtual Engine';

--- a/Readme.md
+++ b/Readme.md
@@ -85,7 +85,7 @@ Other generous members of the community have written some comprehensive guides t
 
 ## Versions
 
-### Unreleased
+### v0.10.2
 
 * Updates bundled xHyper-V DSC resource module to 3.5.0.0
 * Updates bundled xPendingReboot DSC resource module to 0.3.0.0


### PR DESCRIPTION
* Updates bundled xHyper-V DSC resource module to 3.5.0.0
* Updates bundled xPendingReboot DSC resource module to 0.3.0.0
* Fixes calls to stop/start Shell Hardware Detection service on Server Core (#175)
* Fixes incorrect WIN10_x86_Enterprise_EN_Eval uri (#183)
* Fixes .VHD files not being removed (#182)
* Fixes .VHDX files not being dismounted when there are errors creating the disk (#185)
* Adds Windows Management Framework 5.1 evaluation media
* Updates examples with xNetworking v3.0.0.0 breaking change (#172)