### PR TITLE
Releasing version 0.10.3

### DIFF
--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Lability.psm1';
-    ModuleVersion = '0.10.2';
+    ModuleVersion = '0.10.3';
     GUID = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author = 'Iain Brighton';
     CompanyName = 'Virtual Engine';

--- a/Readme.md
+++ b/Readme.md
@@ -82,11 +82,11 @@ Other generous members of the community have written some comprehensive guides t
 * [The Ultimate Hyper-V Lab Tool](http://www.absolutejam.co.uk/blog/lability-ultimate-hyperv-lab-tool/) via @absolutejam
 * [Create Your Virtual Lab Environment with Lability How-To](http://blog.mscloud.guru/2016/09/17/create-your-virtual-lab-environment-with-lability-howto/) via @Naboo2604
 * [Microsoft Channel 9 PSDEVOPS](https://channel9.msdn.com/Blogs/PSDEVOPSSIG/PSDEVOPSSIGEventLability-Demo-w-Iain-Brigton) presentation recording
-* [Using Lability, DSC and ARM to define and deploy multi-VM environments](https://blogs.blackmarble.co.uk/blogs/rhepworth/post/2017/03/02/Define-Once-Deploy-Everywhere-(Sort-of…)) via @@rikhepworth
+* [Using Lability, DSC and ARM to define and deploy multi-VM environments](https://blogs.blackmarble.co.uk/blogs/rhepworth/post/2017/03/02/Define-Once-Deploy-Everywhere-(Sort-of…)) via @rikhepworth
 
 ## Versions
 
-### Unreleased
+### v0.10.3
 
 * Adds -Confirm/-WhatIf support to:
   * Start-LabConfiguration, Remove-LabConfiguration


### PR DESCRIPTION
* Adds -Confirm/-WhatIf support to:
  * Start-LabConfiguration, Remove-LabConfiguration
  * Start-Lab, Stop-Lab, Reset-Lab and Restore-Lab
* Searches $PWD folder and EnvironmentName sub folder for .mof files (#181)
* Throws error if unsupported module values are defined (#170)
* Fixes error copying resource files into custom VHD Windows media (#193)
* Adds credential encryption/certificate support on Nano server
* Permits overriding VM generation with the Media\CustomData\VmGeneration property (#194)
* Adds -RepositoryUri parameter to Set-LabHostDefault to support internal repositories (partially implements #195)
* Changes default PowerShell gallery URI to HTTPS
* Removes mounted ISOs when parent VHD/X image creation fails (#166)
* Updates bundled xHyper-V DSC resource module to 3.7.0.0
* Adds setting the default shell via media 'CustomData\DefaultShell' setting