### PR TITLE
Update Expand-LabImage.ps1

### DIFF
--- a/Src/Private/Expand-LabImage.ps1
+++ b/Src/Private/Expand-LabImage.ps1
@@ -80,7 +80,7 @@ function Expand-LabImage {
                 }
                 $iso = Mount-DiskImage @mountDiskImageParams;
                 $iso = Get-DiskImage -ImagePath $iso.ImagePath;
-                $isoDriveLetter = $iso | Get-Volume | Select-Object -ExpandProperty DriveLetter;
+                $isoDriveLetter = Get-Volume -DiskImage $iso | Select-Object -ExpandProperty DriveLetter;
 
                 ## Update the media path to point to the mounted ISO
                 $windowsImagePath = '{0}:{1}' -f $isoDriveLetter, $WimPath;


### PR DESCRIPTION
Modified the way the iso driveletter is being determined. On my OS (W10) the previous function would fail.