### PR TITLE
Update NanoComputeExample.ps1

### DIFF
--- a/Examples/NanoComputeExample.ps1
+++ b/Examples/NanoComputeExample.ps1
@@ -24,7 +24,7 @@ Configuration NanoComputeExample {
 
                 IPAddress      = $node.IPAddress;
                 InterfaceAlias = $node.InterfaceAlias;
-                PrefixLength   = $node.PrefixLength;
+                #PrefixLength   = $node.PrefixLength;
                 AddressFamily  = $node.AddressFamily;
             }
 


### PR DESCRIPTION
When running this configuration, this error occurs:
At line:27 char:17
+                 PrefixLength   = $node.PrefixLength;
+                 ~~~~~~~~~~~~
The member 'PrefixLength' is not valid. Valid members are
'AddressFamily', 'DependsOn', 'InterfaceAlias', 'IPAddress', 'PsDscRunAsCredential'.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidInstanceProperty

#'ing out line 27 enables it to run without error.