### PR TITLE
use timezone Id instead of localized StandardName

### DIFF
--- a/Src/Private/Assert-TimeZone.ps1
+++ b/Src/Private/Assert-TimeZone.ps1
@@ -14,7 +14,7 @@ function Assert-TimeZone {
         try {
 
             $TZ = [TimeZoneInfo]::FindSystemTimeZoneById($TimeZone)
-            return $TZ.StandardName;
+            return $TZ.Id;
         }
         catch [System.TimeZoneNotFoundException] {
 


### PR DESCRIPTION
Fix an issue where the timezone would not be applied on a non-English (German) host OS because the string "Mitteleuropäische Zeit" would be written to the injected unattend.xml instead of the correct string "W. Europe Standard Time".

On a non-English OS, the ID contains the English timezone string, while the StandardName contains a localized version; see the following output for [TimeZoneInfo]::FindSystemTimeZoneById:

![2017-11-21 19_28_24-administrator_ windows powershell](https://user-images.githubusercontent.com/16491101/33089847-380db3ac-cef2-11e7-8540-496b8d13e7d1.png)

For the timezone to be applied correctly via unattend.xml, the English string should be used.