### PR TITLE
Minor change to Start-LabHostConfiguration.ps1

### DIFF
--- a/Src/Public/Start-LabHostConfiguration.ps1
+++ b/Src/Public/Start-LabHostConfiguration.ps1
@@ -57,6 +57,20 @@ function Start-LabHostConfiguration {
         foreach ($configuration in $labHostSetupConfiguation) {
 
             Import-LabDscResource -ModuleName $configuration.ModuleName -ResourceName $configuration.ResourceName -Prefix $configuration.Prefix -UseDefault:$configuration.UseDefault;
+            
+            ## Pending reboot switch being ignored. Fixed with this clause
+            if ( $IgnorePendingReboot ) {
+
+                if ( $configuration.Prefix -eq "PendingReboot" ) {
+                    WriteVerbose (
+                        "IgnorePendingReboot switch specified. Skipping DscResource: {0}" -f
+                        $configuration.Prefix
+                    )
+                    Continue
+                }
+            }
+            ### end custom code
+            
             WriteVerbose ($localized.TestingNodeConfiguration -f $Configuration.Description);
             [ref] $null = Invoke-LabDscResource -ResourceName $configuration.Prefix -Parameters $configuration.Parameters;
             ## TODO: Need to check for pending reboots..


### PR DESCRIPTION
The IgnorePendingReboot switch is being ignored and in CI environments, this kills the whole build process. I've added a basic check to see if that switch has been specified and to ignore implementing the pending reboot Dsc resource. 