### PR TITLE
Releasing 0.15.0

### DIFF
--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.14.0';
+    ModuleVersion     = '0.15.0';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';

--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,7 @@ written some comprehensive guides to compliment the built-in documentation – a
 
 ## Versions ##
 
-### Unreleased ###
+### v0.15.0 ###
 
 * Removes "experimental" tag from attaching multiple VHD files to VMs (#218)
   * See Examples\MultipleDiskExample.psd1


### PR DESCRIPTION
* Removes "experimental" tag from attaching multiple VHD files to VMs (#218)
* Adds support for creating both fixed and dynamic VHD files (#99)
* Adds support for creating empty/blank media (#135)
* Removes errant "Specify MaximumSizeBytes property" xVHD errors
* Adds support for configuring the WSMan MaxEnvelopeSizeKb setting (#282)
* Updates built-in Windows 10 Enterprise evaluation media with the 1803 'April 2018 Update' ISOs
* Fixes removal of additional disks/VHDs when using an environment prefix (#292)
* Fixes bug in automatic checkpoint detection on Windows 10 build 1703 (and earlier) (#294)
* Changes the default internal virtual switch name from 'Internal vSwitch' to 'Default Switch'