### PR TITLE
Releasing v0.15.1

### DIFF
--- a/Config/Media.json
+++ b/Config/Media.json
@@ -682,7 +682,7 @@
 	"MediaType": "ISO",
     "OperatingSystem": "Windows",
 	"Uri": "https://software-download.microsoft.com/download/pr/17134.1.180410-1804.rs4_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
-	"Checksum": "F4F85D77516721D9A19CA866172A5ECB",
+	"Checksum": "767141F88C9C6FE5220F093C36568A39",
     "CustomData": {
 		"WindowsOptionalFeature": ["NetFx3"],
 		"CustomBootstrap": [

--- a/Config/Media.json
+++ b/Config/Media.json
@@ -459,7 +459,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		]
@@ -510,7 +510,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		]
@@ -537,7 +537,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		]
@@ -564,7 +564,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		]
@@ -611,7 +611,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		]
@@ -638,7 +638,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		]
@@ -665,7 +665,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		],
@@ -688,7 +688,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		],
@@ -711,7 +711,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		],
@@ -734,7 +734,7 @@
 		"CustomBootstrap": [
 			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 			"NET USER Administrator /active:yes;",
-			"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
 			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
 			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
 		],

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.15.0';
+    ModuleVersion     = '0.15.1';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';

--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,8 @@ written some comprehensive guides to compliment the built-in documentation – a
 ### Unreleased ###
 
 * Fixes incorrect WIN10_x86_Enterprise_EN_Eval RS4 ISO checksum (#305)
+* Fixes MaxEnvelopeSizekb bootstrap network profile error on newer Windows 10 releases (#306)
+* Fixes bootstrap error when setting execution policy on newer Windows 10 releases (#306)
 
 ### v0.15.0 ###
 

--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,7 @@ written some comprehensive guides to compliment the built-in documentation – a
 
 ## Versions ##
 
-### Unreleased ###
+### v0.15.1 ###
 
 * Fixes incorrect WIN10_x86_Enterprise_EN_Eval RS4 ISO checksum (#305)
 * Fixes MaxEnvelopeSizekb bootstrap network profile error on newer Windows 10 releases (#306)

--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,10 @@ written some comprehensive guides to compliment the built-in documentation – a
 
 ## Versions ##
 
+### Unreleased ###
+
+* Fixes incorrect WIN10_x86_Enterprise_EN_Eval RS4 ISO checksum (#305)
+
 ### v0.15.0 ###
 
 * Removes "experimental" tag from attaching multiple VHD files to VMs (#218)

--- a/Src/Private/New-LabBootStrap.ps1
+++ b/Src/Private/New-LabBootStrap.ps1
@@ -52,8 +52,8 @@ certutil.exe -addstore -f "Root" "$env:SYSTEMDRIVE\BootStrap\LabRoot.cer";
 
 <#CustomBootStrapInjectionPoint#>
 
-## Account for large configurations being "pushed" and increase the default from 500KB to <#MaxEnvelopeSizeKb#>KB
-Set-Item -Path WSMan:\localhost\MaxEnvelopeSizekb -Value <#MaxEnvelopeSizeKb#> -Force -Verbose;
+## Account for large configurations being "pushed" and increase the default from 500KB to <#MaxEnvelopeSizeKb#>KB (#306)
+Set-ItemProperty -LiteralPath HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Client -Name maxEnvelopeSize -Value <#MaxEnvelopeSizeKb#> -Force -Verbose
 
 if (Test-Path -Path "$env:SystemDrive\BootStrap\localhost.meta.mof") {
     Set-DscLocalConfigurationManager -Path "$env:SystemDrive\BootStrap\" -Verbose;


### PR DESCRIPTION
* Fixes incorrect WIN10_x86_Enterprise_EN_Eval RS4 ISO checksum
  * Fixes #305
* Fixes bootstrap error when setting execution policy on newer Windows 10 releases
* Fixes MaxEnvelopeSizekb bootstrap network profile error on newer Windows 10 releases
  * Fixes #306
