### PR TITLE
Add Invoke-LabMediaImageDownload to VHD creation - fixes #309

### DIFF
--- a/Src/Public/New-LabImage.ps1
+++ b/Src/Public/New-LabImage.ps1
@@ -77,6 +77,7 @@ function New-LabImage {
 
         if ($media.MediaType -eq 'VHD') {
 
+            $mediaFileInfo = Invoke-LabMediaImageDownload -Media $media;
             Write-Verbose -Message ($localized.ImportingExistingDiskImage -f $media.Description);
             $imageName = $media.Filename;
             $imagePath = Join-Path -Path $hostDefaults.ParentVhdPath -ChildPath $imageName;


### PR DESCRIPTION
VHD media files weren't being downloaded following changes in 0.15.0, this adds the download back in. Also added a test for this.