### PR TITLE
Releasing v0.16.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Versions ##
 
-### Unreleased ###
+### v0.16.0 ###
 
 * Fixes bug downloading external VHD media (#309)
 * Fixes incorrectly named Get-WindowsImageByName and Get-WindowsImageByIndex functions

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.15.1';
+    ModuleVersion     = '0.16.0';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';


### PR DESCRIPTION
* Fixes bug downloading external VHD media (#309)
* Fixes incorrectly named Get-WindowsImageByName and Get-WindowsImageByIndex functions
* Fixes bug testing computer name length with environment prefixes/suffixes (#314)
* Fixes bug with no external DSC resource dependencies (#316)
* Adds support for registering custom media from a .json file
