### PR TITLE
Added code row to enable admin account

### DIFF
--- a/en-US/about_Bootstrap.help.txt
+++ b/en-US/about_Bootstrap.help.txt
@@ -92,6 +92,7 @@ MEDIA BOOTSTRAP
         $customData = @{
             CustomBootstrap = @(
                 '## Unattend.xml will set the Administrator password, but it won''t enable the account on client OSes',
+                'NET USER Administrator /active:yes',
                 'Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force;',
                 '## Kick-start PowerShell remoting on clients to permit applying DSC configurations',
                 'Enable-PSRemoting -SkipNetworkProfileCheck -Force;'


### PR DESCRIPTION
Not sure if this was intentional or not, but the example for Media custom bootstrap has a comment on enabling the admin account and the actual code is missing. Added the code.

Feel free to reject the PR if I misunderstood.