### PR TITLE
Adds support for defining node names with FQDNs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 * Adds checksum support for media hotfixes (#329)
 * Updates calls to Hyper-V and Storage module commands to use module-qualified names (#333)
 * Adds support for defining node names with FQDNs (#335)
+  * Adds 'UseNetBIOSName' parameter to enforce VM and disk filenames are created using NetBIOS name format
 
 ### v0.16.0 ###
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 * Adds checksum support for media hotfixes (#329)
 * Updates calls to Hyper-V and Storage module commands to use module-qualified names (#333)
+* Adds support for defining node names with FQDNs (#335)
 
 ### v0.16.0 ###
 

--- a/Config/VMDefaults.json
+++ b/Config/VMDefaults.json
@@ -16,5 +16,6 @@
     "RootCertificatePath": "%ALLUSERSPROFILE%\\Lability\\Certificates\\LabRoot.cer",
     "BootOrder": 99,
     "BootDelay": 0,
-	"CustomBootstrapOrder": "MediaFirst"
+    "CustomBootstrapOrder": "MediaFirst",
+    "UseNetBIOSName": false
 }

--- a/Src/Private/Get-ConfigurationData.ps1
+++ b/Src/Private/Get-ConfigurationData.ps1
@@ -49,6 +49,12 @@ function Get-ConfigurationData {
 
                         [ref] $null = Add-Member -InputObject $configurationData -MemberType NoteProperty -Name 'MaxEnvelopeSizeKb' -Value 1024;
                     }
+
+                    ## This property may not be present in the original VM default file. Defaults to $false
+                    if ($configurationData.PSObject.Properties.Name -notcontains 'UseNetBIOSName') {
+
+                        [ref] $null = Add-Member -InputObject $configurationData -MemberType NoteProperty -Name 'UseNetBIOSName' -Value $false;
+                    }
                 }
                 'CustomMedia' {
 

--- a/Src/Private/New-LabVirtualMachine.ps1
+++ b/Src/Private/New-LabVirtualMachine.ps1
@@ -60,7 +60,7 @@ function New-LabVirtualMachine {
         ## Display name includes any environment prefix/suffix
         $displayName = $node.NodeDisplayName;
 
-        if (-not (Test-ComputerName -ComputerName $node.NodeName)) {
+        if (-not (Test-ComputerName -ComputerName $node.NodeName.Split('.')[0])) {
 
             throw ($localized.InvalidComputerNameError -f $node.NodeName);
         }

--- a/Src/Private/Resolve-NodePropertyValue.ps1
+++ b/Src/Private/Resolve-NodePropertyValue.ps1
@@ -62,14 +62,18 @@ function Resolve-NodePropertyValue {
             }
         }
 
-        $moduleName = $labDefaults.ModuleName;
         $resolveLabEnvironmentNameParams = @{
             Name              = $NodeName;
             ConfigurationData = $ConfigurationData;
         }
         ## Set the node's friendly/display name with any prefix/suffix
-        $node["$($moduleName)_NodeDisplayName"] = Resolve-LabEnvironmentName @resolveLabEnvironmentNameParams;
+        $node['NodeDisplayName'] = Resolve-LabEnvironmentName @resolveLabEnvironmentNameParams;
+        ## Use the prefixed/suffixed NetBIOSName is specified
+        if ($node.UseNetBIOSName -eq $true) {
+            $node['NodeDisplayName'] = $node['NodeDisplayName'].Split('.')[0];
+        }
 
+        $moduleName = $labDefaults.ModuleName;
         ## Rename/overwrite existing parameter values where $moduleName-specific parameters exist
         foreach ($key in @($node.Keys)) {
 

--- a/Src/Private/Set-LabVMDiskFileUnattendXml.ps1
+++ b/Src/Private/Set-LabVMDiskFileUnattendXml.ps1
@@ -41,7 +41,7 @@ function Set-LabVMDiskFileUnattendXml {
 
         ## Create Unattend.xml
         $newUnattendXmlParams = @{
-            ComputerName = $node.NodeName;
+            ComputerName = $node.NodeName.Split('.')[0]; # Convert any FQDN to NetBIOS (#335)
             Credential = $Credential;
             InputLocale = $node.InputLocale;
             SystemLocale = $node.SystemLocale;

--- a/Src/Public/Set-LabVMDefault.ps1
+++ b/Src/Public/Set-LabVMDefault.ps1
@@ -104,7 +104,13 @@ function Set-LabVMDefault {
 
         ## WSMan maximum envelope size
         [Parameter(ValueFromPipelineByPropertyName)]
-        [System.Int32] $MaxEnvelopeSizeKb
+        [System.Int32] $MaxEnvelopeSizeKb,
+
+        ## By default, all virtual machines and their associated disks are created using the node name as it is
+        ## defined in the .psd1 configuration file. This name can be either a FQDN or a NetBIOS name format. Enabling
+        ## the 'UseNetBIOSName' forces all VMs and disk files to be created using the NetBIOS (short) name format.
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [System.Management.Automation.SwitchParameter] $UseNetBIOSName
     )
     process {
 
@@ -231,6 +237,11 @@ function Set-LabVMDefault {
         if ($PSBoundParameters.ContainsKey('MaxEnvelopeSizeKb')) {
 
             $vmDefaults.MaxEnvelopeSizeKb = $MaxEnvelopeSizeKb;
+        }
+
+        if ($PSBoundParameters.ContainsKey('UseNetBIOSName')) {
+
+            $vmDefaults.UseNetBIOSName = $UseNetBIOSName.ToBool();
         }
 
         if ($vmDefaults.StartupMemory -lt $vmDefaults.MinimumMemory) {

--- a/Tests/Unit/Src/Private/Get-ConfigurationData.Tests.ps1
+++ b/Tests/Unit/Src/Private/Get-ConfigurationData.Tests.ps1
@@ -127,6 +127,19 @@ Describe 'Unit\Src\Private\Get-ConfigurationData' {
             $vmConfiguration.MaxEnvelopeSizeKb | Should Be 1024;
         }
 
+        It 'Adds missing "UseNetBIOSName" property to VM configuration' {
+            $testConfigurationFilename = 'TestVMConfiguration.json';
+            $testConfigurationPath = "$env:SystemRoot\Temp\$testConfigurationFilename";
+            $fakeConfiguration = '{ "ConfigurationPath": "%SYSTEMDRIVE%\\TestLab\\Configurations" }';
+            [ref] $null = New-Item -Path $testConfigurationPath -ItemType File -Force;
+            Mock Resolve-ConfigurationDataPath -MockWith { return $testConfigurationPath }
+            Mock Get-Content -MockWith { return $fakeConfiguration; }
+
+            $vmConfiguration = Get-ConfigurationData -Configuration VM;
+
+            $vmConfiguration.UseNetBIOSName -eq $false | Should Be $true;
+        }
+
     } #end InModuleScope
 
 } #end Describe

--- a/Tests/Unit/Src/Private/Resolve-NodePropertyValue.Tests.ps1
+++ b/Tests/Unit/Src/Private/Resolve-NodePropertyValue.Tests.ps1
@@ -141,6 +141,19 @@ Describe 'Unit\Src\Private\Resolve-NodePropertyValue' {
             $vmProperties.NodeDisplayName | Should Be $expected;
         }
 
+        It 'Returns NetBIOS display name when FQDN defined and UseNetBIOSName = "true" (#335)' {
+            $testVMName = 'TestVM';
+            $testVMDomainName = 'lab.local';
+            $testNodeName = "$testVMName.$testVMDomainName";
+            $configurationData = @{
+                AllNodes = @( @{ NodeName = $testNodeName; UseNetBIOSName = $true; } )
+            }
+
+            $vmProperties = Resolve-NodePropertyValue -ConfigurationData $configurationData -NodeName $testNodeName;
+
+            $vmProperties.NodeDisplayName | Should Be $testVMName;
+        }
+
     } #end InModuleScope
 
 } #end describe

--- a/Tests/Unit/Src/Private/Set-LabVMDiskFileUnattendXml.Tests.ps1
+++ b/Tests/Unit/Src/Private/Set-LabVMDiskFileUnattendXml.Tests.ps1
@@ -134,6 +134,30 @@ Describe 'Unit\Src\Private\Set-LabVMDiskFileUnattendXml' {
             Assert-MockCalled Set-UnattendXml -ParameterFilter { $ProductKey -eq $testNodeProductKey } -Scope It;
         }
 
+        It 'Passes node "NetBIOS" name when node name is a FQDN (#335)' {
+
+            $testNode = 'TestNode.lab.local';
+            $testConfigurationData = @{
+                AllNodes = @(
+                    @{ NodeName = $testNode; }
+                )
+            }
+            $testDriveLetter = $env:SystemDrive.Trim(':');
+            $testCredential = $testCredential = New-Object System.Management.Automation.PSCredential 'DummyUser', (ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force);;
+
+            Mock Set-UnattendXml -MockWith { }
+
+            $testParams = @{
+                ConfigurationData = $testConfigurationData;
+                NodeName = $testNode;
+                VhdDriveLetter = $testDriveLetter;
+                Credential = $testCredential;
+            }
+            Set-LabVMDiskFileUnattendXml @testParams;
+
+            Assert-MockCalled Set-UnattendXml -ParameterFilter { $ComputerName -eq 'TestNode' } -Scope It;
+        }
+
     } #end InModuleScope
 
 } #end describe

--- a/Tests/Unit/Src/Public/Set-LabVMDefault.Tests.ps1
+++ b/Tests/Unit/Src/Public/Set-LabVMDefault.Tests.ps1
@@ -36,6 +36,7 @@ Describe 'Unit\Src\Public\Set-LabVMDefault' {
             @{ CustomBootstrapOrder = 'Disabled'; }
             @{ GuestIntegrationServices = $true; }
             @{ MaxEnvelopeSizeKb = 2048; }
+            @{ UseNetBIOSName = $true; }
         )
         foreach ($property in $testProperties) {
 


### PR DESCRIPTION
* Fixes #335`
* Adds `-UseNetBIOSName` parameter to `Set-LabVMDefault` to enforce VM and disk filenames are created using NetBIOS name format