### PR TITLE
Releasing v0.20.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,14 +2,14 @@
 
 ## Versions ##
 
-### Unreleased ###
+### 0.20.0 ###
 
 * Updates default Windows 10 evaluation media to Windows 10 20H2 (2009)
 * Adds Windows 10 20H1 (2004) evaluation media
 * Adds aliases for latest Windows 10 evaluation media avoiding breaking existing VHD/X chains (or in future)
   * To lock to a specific Windows 10 version, use its media Id - not its alias
   * `WIN10_x64_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x64_Enterprise_20H2_EN_Eval`)
-  * `WIN10_x86_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x86_Enterprise_20H2_EN_Eval`)
+  * `WIN10_x86_Enterprise_EN_Eval` will always point to the latest Windows 10 x86 version (currently `WIN10_x86_Enterprise_20H2_EN_Eval`)
 * Fixes bug in custom bootstrap injection with Regex substituion string(s), e.g. $&
 
 ### v0.19.1 ###

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
   * To lock to a specific Windows 10 version, use its media Id - not its alias
   * `WIN10_x64_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x64_Enterprise_20H1_EN_Eval`)
   * `WIN10_x86_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x86_Enterprise_20H1_EN_Eval`)
+* Fixes bug in custom bootstrap with Regex substituion string(s), e.g. $&
 
 ### v0.19.1 ###
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,12 +4,13 @@
 
 ### Unreleased ###
 
-* Updates default Windows 10 evaluation media to Windows 10 20H1 (2004)
+* Updates default Windows 10 evaluation media to Windows 10 20H2 (2009)
+* Adds Windows 10 20H1 (2004) evaluation media
 * Adds aliases for latest Windows 10 evaluation media avoiding breaking existing VHD/X chains (or in future)
   * To lock to a specific Windows 10 version, use its media Id - not its alias
-  * `WIN10_x64_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x64_Enterprise_20H1_EN_Eval`)
-  * `WIN10_x86_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x86_Enterprise_20H1_EN_Eval`)
-* Fixes bug in custom bootstrap with Regex substituion string(s), e.g. $&
+  * `WIN10_x64_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x64_Enterprise_20H2_EN_Eval`)
+  * `WIN10_x86_Enterprise_EN_Eval` will always point to the latest Windows 10 x64 version (currently `WIN10_x86_Enterprise_20H2_EN_Eval`)
+* Fixes bug in custom bootstrap injection with Regex substituion string(s), e.g. $&
 
 ### v0.19.1 ###
 

--- a/Config/LegacyMedia/WIN10_x64_Enterprise_2004_EN_Eval.json
+++ b/Config/LegacyMedia/WIN10_x64_Enterprise_2004_EN_Eval.json
@@ -1,0 +1,23 @@
+{
+	"Id": "WIN10_x64_Enterprise_20H1_EN_Eval",
+    "Filename": "WIN10_x64_ENT_20H1_EN_Eval.iso",
+    "Description": "Windows 10 64bit Enterprise 2004 English Evaluation",
+	"Architecture": "x64",
+	"ImageName": "Windows 10 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+	"Checksum": "E85637E135E9B6DBC5FA02B463A95764",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		],
+		"MinimumDismVersion": "10.0.0.0"
+	},
+    "Hotfixes": []
+}

--- a/Config/LegacyMedia/WIN10_x86_Enterprise_2004_EN_Eval.json
+++ b/Config/LegacyMedia/WIN10_x86_Enterprise_2004_EN_Eval.json
@@ -1,0 +1,23 @@
+{
+	"Id": "WIN10_x86_Enterprise_20H1_EN_Eval",
+    "Filename": "WIN10_x86_ENT_20H1_EN_Eval.iso",
+    "Description": "Windows 10 32bit Enterprise 2004 English Evaluation",
+	"Architecture": "x86",
+	"ImageName": "Windows 10 Enterprise Evaluation",
+	"MediaType": "ISO",
+    "OperatingSystem": "Windows",
+	"Uri": "https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+	"Checksum": "895283EEA7A5D53A2BD6F071BABBB4F1",
+    "CustomData": {
+		"WindowsOptionalFeature": ["NetFx3"],
+		"CustomBootstrap": [
+			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+			"NET USER Administrator /active:yes;",
+			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		],
+		"MinimumDismVersion": "10.0.0.0"
+	},
+    "Hotfixes": []
+}

--- a/Config/Media.json
+++ b/Config/Media.json
@@ -712,16 +712,16 @@
 	]
 },
 {
-	"Id": "WIN10_x64_Enterprise_20H1_EN_Eval",
+	"Id": "WIN10_x64_Enterprise_20H2_EN_Eval",
 	"Alias": "WIN10_x64_Enterprise_EN_Eval",
-    "Filename": "WIN10_x64_ENT_20H1_EN_Eval.iso",
-    "Description": "Windows 10 64bit Enterprise 2004 English Evaluation",
+    "Filename": "WIN10_x64_ENT_20H2_EN_Eval.iso",
+    "Description": "Windows 10 64bit Enterprise 2009 English Evaluation",
 	"Architecture": "x64",
 	"ImageName": "Windows 10 Enterprise Evaluation",
 	"MediaType": "ISO",
     "OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
-	"Checksum": "E85637E135E9B6DBC5FA02B463A95764",
+	"Uri": "https://software-download.microsoft.com/download/pr/19042.631.201119-0144.20h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+	"Checksum": "3B5DA0C84DACDB89ABF4502D79CF0CA4",
     "CustomData": {
 		"WindowsOptionalFeature": ["NetFx3"],
 		"CustomBootstrap": [
@@ -736,16 +736,16 @@
     "Hotfixes": []
 },
 {
-	"Id": "WIN10_x86_Enterprise_20H1_EN_Eval",
+	"Id": "WIN10_x86_Enterprise_20H2_EN_Eval",
 	"Alias": "WIN10_x86_Enterprise_EN_Eval",
-    "Filename": "WIN10_x86_ENT_20H1_EN_Eval.iso",
-    "Description": "Windows 10 32bit Enterprise 2004 English Evaluation",
+    "Filename": "WIN10_x86_ENT_20H2_EN_Eval.iso",
+    "Description": "Windows 10 32bit Enterprise 2009 English Evaluation",
 	"Architecture": "x86",
 	"ImageName": "Windows 10 Enterprise Evaluation",
 	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/pr/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
-	"Checksum": "895283EEA7A5D53A2BD6F071BABBB4F1",
+	"OperatingSystem": "Windows",
+	"Uri": "https://software-download.microsoft.com/download/pr/19042.631.201119-0144.20h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+	"Checksum": "7C4EAAC7A6FE514EA0CB48AE8AC790FE",
     "CustomData": {
 		"WindowsOptionalFeature": ["NetFx3"],
 		"CustomBootstrap": [

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,10 +1,10 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.19.1';
+    ModuleVersion     = '0.20.0';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';
-    Copyright         = '(c) 2019 Virtual Engine Limited. All rights reserved.';
+    Copyright         = '(c) 2021 Virtual Engine Limited. All rights reserved.';
     Description       = 'The Lability module contains cmdlets for provisioning Hyper-V test lab and development environments.';
     PowerShellVersion = '4.0';
     FormatsToProcess  = @('Lability.Format.ps1xml');

--- a/Src/Private/New-LabBootStrap.ps1
+++ b/Src/Private/New-LabBootStrap.ps1
@@ -122,7 +122,7 @@ Stop-Transcript;
             }
 
             $shellScriptBlockString = $shellScriptBlock.ToString() -f $DefaultShell;
-            $bootstrap = $bootStrap -replace '<#CustomBootStrapInjectionPoint#>', $shellScriptBlockString;
+            $bootstrap = $bootStrap.Replac('<#CustomBootStrapInjectionPoint#>', $shellScriptBlockString);
         }
 
         $bootstrap = $bootstrap -replace  '<#MaxEnvelopeSizeKb#>', $MaxEnvelopeSizeKb;

--- a/Src/Private/Set-LabBootStrap.ps1
+++ b/Src/Private/Set-LabBootStrap.ps1
@@ -41,7 +41,7 @@ function Set-LabBootStrap {
 
         if ($CustomBootStrap) {
 
-            $bootStrap = $bootStrap -replace '<#CustomBootStrapInjectionPoint#>', $CustomBootStrap;
+            $bootStrap = $bootStrap.Replace('<#CustomBootStrapInjectionPoint#>', $CustomBootStrap);
         }
 
         [ref] $null = New-Directory -Path $Path -Confirm:$false;


### PR DESCRIPTION
* Updates default Windows 10 evaluation media to Windows 10 20H2 (2009)
* Adds Windows 10 20H1 (2004) evaluation media
* Adds aliases for latest Windows 10 evaluation media avoiding breaking existing VHD/X chains (or in future)
* Fixes bug in custom bootstrap injection with Regex substitution string(s), e.g. $&