### PR TITLE
Rename field 'Url' to 'Uri' in media.json

### DIFF
--- a/Config/Media.json
+++ b/Config/Media.json
@@ -720,7 +720,7 @@
 	"ImageName": "Windows 10 Enterprise Evaluation",
 	"MediaType": "ISO",
     "OperatingSystem": "Windows",
-	"Url": "https://software-download.microsoft.com/download/sg/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+	"Uri": "https://software-download.microsoft.com/download/sg/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
 	"Checksum": "AE1DA210FFFA81BB6A8DF455ECA9636B",
     "CustomData": {
 		"WindowsOptionalFeature": ["NetFx3"],


### PR DESCRIPTION
Hi,

I was following one of the lability tutorials listed in the repository readme and had a problem using the code listed. I think there is a problem in media.json where one of the resources has a "Url" field that actually should be "Uri". This pull request fixes this.

To recreate the issue do:
`Invoke-LabResourceDownload -MediaID 'WIN10_x64_Enterprise_21H2_EN_Eval'`
Without the fix it outputs: 
New-Object : A constructor was not found. Cannot find an appropriate constructor for type System.Uri.
At line:36 char:21
\+ ... $mediaUri = New-Object -TypeName System.Uri -ArgumentList $Media.Uri; ...
etc...
Changing the field from "Url" to "Uri" fixes this.