### PR TITLE
Fixes bug in `WIN10_x64_Enterprise_21H2_EN_Eval` media link

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ### Unreleased ###
 
+### 0.21.1 ###
+
+* Fixes bug in `WIN10_x64_Enterprise_21H2_EN_Eval` media download link (@ToreAad)
+
 ### 0.21.0 ###
 
 * Updates code signing certificate

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.21.0';
+    ModuleVersion     = '0.21.1';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';


### PR DESCRIPTION
Updates `ChangeLog.md` and bumps version to `0.21.1` for release