### PR TITLE
Releasing v0.22.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ### Unreleased ###
 
+### 0.21.1 ###
+
+* Fixes bug in `WIN10_x64_Enterprise_21H2_EN_Eval` media download link (@ToreAad)
+
 ### 0.21.0 ###
 
 * Updates code signing certificate

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,12 @@
 
 ### Unreleased ###
 
+### 0.22.0 ###
+
+* Adds Windows 11 Enterprise 22H2 (2209) evaluation media
+* Adds Adds Windows Server 2022 evaluation media
+* Updates default VM media from `2019_x64_Standard_EN_Eval` to `2022_x64_Datacenter_EN_Eval` (#406)
+
 ### 0.21.1 ###
 
 * Fixes bug in `WIN10_x64_Enterprise_21H2_EN_Eval` media download link (@ToreAad)
@@ -13,7 +19,7 @@
 * Updates code signing certificate
 * Disables network location wizard notification(s)
 * Adds Windows 10 Enterprise 21H2 (2109) evaluation media
-* Adds Windows 11 21H2 (2109) evaluation media
+* Adds Windows 11 Enterprise 21H2 (2109) evaluation media
 * Adds Windows 10 LTSC 2021 evaluation media
 
 ### 0.20.0 ###

--- a/Config/LegacyMedia/WIN11_x64_Enterprise_21H2_EN_Eval.json
+++ b/Config/LegacyMedia/WIN11_x64_Enterprise_21H2_EN_Eval.json
@@ -1,0 +1,23 @@
+{
+    "Id": "WIN11_x64_Enterprise_21H2_EN_Eval",
+    "Filename": "WIN11_x64_ENT_21H2_EN_Eval.iso",
+    "Description": "Windows 11 64bit Enterprise 21H2 English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "1",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "https://software-download.microsoft.com/download/sg/22000.194.210913-1444.co_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "Checksum": "86034E9DA681217E0C7D8A23A27BCF13",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"],
+        "CustomBootstrap": [
+            "## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+            "NET USER Administrator /active:yes;",
+            "Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+            "## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+            "Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+        ],
+        "MinimumDismVersion": "10.0.0.0"
+    },
+    "Hotfixes": []
+}

--- a/Config/Media.json
+++ b/Config/Media.json
@@ -1,833 +1,902 @@
-[{
-    "Id":  "2019_x64_Standard_EN_Eval",
-    "Filename":  "2019_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2019 Standard 64bit English Evaluation with Desktop Experience",
-    "Architecture":  "x64",
-    "ImageName":  "2",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-        "MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},{
-    "Id":  "2019_x64_Standard_EN_Core_Eval",
-    "Filename":  "2019_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2019 Standard 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "1",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-        "MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},{
-    "Id":  "2019_x64_Datacenter_EN_Eval",
-    "Filename":  "2019_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2019 Datacenter 64bit English Evaluation with Desktop Experience",
-    "Architecture":  "x64",
-    "ImageName":  "4",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-        "MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},{
-    "Id":  "2019_x64_Datacenter_EN_Core_Eval",
-    "Filename":  "2019_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2019 Datacenter Evaluation in Core mode",
-    "Architecture":  "x64",
-    "ImageName":  "3",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-        "MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id":  "2016_x64_Standard_EN_Eval",
-    "Filename":  "2016_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2016 Standard 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "2",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
-    "Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "CustomData":  {
-		"WindowsOptionalFeature":  ["NetFx3"],
-		"MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id":  "2016_x64_Standard_Core_EN_Eval",
-    "Filename":  "2016_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2016 Standard Core 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "1",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
-    "Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-		"MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id":  "2016_x64_Datacenter_EN_Eval",
-    "Filename":  "2016_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2016 Datacenter 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "4",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
-    "Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-		"MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id":  "2016_x64_Datacenter_Core_EN_Eval",
-    "Filename":  "2016_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2016 Datacenter Core 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "3",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
-    "Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "CustomData":  {
-        "WindowsOptionalFeature":  ["NetFx3"],
-		"MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id":  "2016_x64_Standard_Nano_EN_Eval",
-    "Filename":  "2016_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2016 Standard Nano 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "Windows Server 2016 SERVERSTANDARDNANO",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
-    "Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "CustomData":  {
-        "SetupComplete":  "CoreCLR",
-        "PackagePath":  "\\NanoServer\\Packages",
-		"PackageLocale": "en-US",
-        "WimPath":  "\\NanoServer\\NanoServer.wim",
-        "Package":  [
-            "Microsoft-NanoServer-Guest-Package",
-            "Microsoft-NanoServer-DSC-Package"
-        ],
-		"MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id":  "2016_x64_Datacenter_Nano_EN_Eval",
-    "Filename":  "2016_x64_EN_Eval.iso",
-    "Description":  "Windows Server 2016 Datacenter Nano 64bit English Evaluation",
-    "Architecture":  "x64",
-    "ImageName":  "Windows Server 2016 SERVERDATACENTERNANO",
-    "MediaType":  "ISO",
-    "OperatingSystem":  "Windows",
-    "Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
-    "Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "CustomData":  {
-        "SetupComplete":  "CoreCLR",
-        "PackagePath":  "\\NanoServer\\Packages",
-		"PackageLocale": "en-US",
-        "WimPath":  "\\NanoServer\\NanoServer.wim",
-        "Package":  [
-            "Microsoft-NanoServer-Guest-Package",
-            "Microsoft-NanoServer-DSC-Package"
-        ],
-		"MinimumDismVersion": "10.0.0.0"
-    },
-    "Hotfixes":  []
-},
-{
-    "Id": "2012R2_x64_Standard_EN_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Standard 64bit English Evaluation",
-    "Architecture": "x64",
-    "ImageName": "2",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+[
+	{
+		"Id":  "2022_x64_Standard_EN_Eval",
+		"Filename":  "2022_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2022 Standard 64bit English Evaluation with Desktop Experience",
+		"Architecture":  "x64",
+		"ImageName":  "2",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "E7908933449613EDC97E1B11180429D1",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Windows8.1-KB2883200-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+	{
+		"Id":  "2022_x64_Standard_EN_Core_Eval",
+		"Filename":  "2022_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2022 Standard 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "1",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "E7908933449613EDC97E1B11180429D1",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
 		},
-		{
-			"Id": "Windows8.1-KB2894029-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB2894179-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3003057-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-		},
-    	{
-			"Id": "Windows8.1-KB3000850-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3014442-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3016437-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Standard_EN_V5_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Standard 64bit English Evaluation with WMF 5",
-    "Architecture": "x64",
-    "ImageName": "2",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-		}
-	]
-},
-{
-    "Id": "2012R2_x64_Standard_EN_V5_1_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Standard 64bit English Evaluation with WMF 5.1",
-    "Architecture": "x64",
-    "ImageName": "2",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2022_x64_Datacenter_EN_Eval",
+		"Filename":  "2022_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2022 Datacenter 64bit English Evaluation with Desktop Experience",
+		"Architecture":  "x64",
+		"ImageName":  "4",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "E7908933449613EDC97E1B11180429D1",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-			"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Standard_Core_EN_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation",
-    "Architecture": "x64",
-    "ImageName": "1",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2022_x64_Datacenter_EN_Core_Eval",
+		"Filename":  "2022_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2022 Datacenter Evaluation in Core mode",
+		"Architecture":  "x64",
+		"ImageName":  "3",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "E7908933449613EDC97E1B11180429D1",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Windows8.1-KB2883200-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+	{
+		"Id":  "2019_x64_Standard_EN_Eval",
+		"Filename":  "2019_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2019 Standard 64bit English Evaluation with Desktop Experience",
+		"Architecture":  "x64",
+		"ImageName":  "2",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
 		},
-		{
-			"Id": "Windows8.1-KB2894029-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB2894179-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3003057-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-		},
-    	{
-			"Id": "Windows8.1-KB3000850-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3014442-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3016437-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Standard_Core_EN_V5_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation with WMF 5",
-    "Architecture": "x64",
-    "ImageName": "1",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Standard_Core_EN_V5_1_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation with WMF 5.1",
-    "Architecture": "x64",
-    "ImageName": "1",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2019_x64_Standard_EN_Core_Eval",
+		"Filename":  "2019_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2019 Standard 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "1",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-			"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Datacenter_EN_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation",
-    "Architecture": "x64",
-	"ImageName": "4",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2019_x64_Datacenter_EN_Eval",
+		"Filename":  "2019_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2019 Datacenter 64bit English Evaluation with Desktop Experience",
+		"Architecture":  "x64",
+		"ImageName":  "4",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Windows8.1-KB2883200-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+	{
+		"Id":  "2019_x64_Datacenter_EN_Core_Eval",
+		"Filename":  "2019_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2019 Datacenter Evaluation in Core mode",
+		"Architecture":  "x64",
+		"ImageName":  "3",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+		"Checksum":  "48CD91270581D1BE10C3FF3AD6C41CCE",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
 		},
-		{
-			"Id": "Windows8.1-KB2894029-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB2894179-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3003057-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-		},
-    	{
-			"Id": "Windows8.1-KB3000850-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3014442-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3016437-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Datacenter_EN_V5_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation with WMF 5",
-    "Architecture": "x64",
-	"ImageName": "4",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Datacenter_EN_V5_1_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation with WMF 5.1",
-    "Architecture": "x64",
-	"ImageName": "4",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2016_x64_Standard_EN_Eval",
+		"Filename":  "2016_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2016 Standard 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "2",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+		"Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-			"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Datacenter_Core_EN_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation",
-    "Architecture": "x64",
-	"ImageName": "3",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2016_x64_Standard_Core_EN_Eval",
+		"Filename":  "2016_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2016 Standard Core 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "1",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+		"Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Windows8.1-KB2883200-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+	{
+		"Id":  "2016_x64_Datacenter_EN_Eval",
+		"Filename":  "2016_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2016 Datacenter 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "4",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+		"Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
 		},
-		{
-			"Id": "Windows8.1-KB2894029-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB2894179-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3003057-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-		},
-    	{
-			"Id": "Windows8.1-KB3000850-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3014442-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3016437-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Datacenter_Core_EN_V5_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation with WMF 5",
-    "Architecture": "x64",
-	"ImageName": "3",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-		}
-	]
-},
-{
-	"Id": "2012R2_x64_Datacenter_Core_EN_V5_1_Eval",
-    "Filename": "2012R2_x64_EN_Eval.iso",
-    "Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation with WMF 5.1",
-    "Architecture": "x64",
-	"ImageName": "3",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-	"CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"]
+	{
+		"Id":  "2016_x64_Datacenter_Core_EN_Eval",
+		"Filename":  "2016_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2016 Datacenter Core 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "3",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+		"Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
+		"CustomData":  {
+			"WindowsOptionalFeature":  ["NetFx3"],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-			"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-		}
-	]
-},
-{
-	"Id": "WIN81_x64_Enterprise_EN_Eval",
-    "Filename": "WIN81_x64_ENT_EN_Eval.iso",
-    "Description": "Windows 8.1 64bit Enterprise English Evaluation",
-	"Architecture": "x64",
-	"ImageName": "Windows 8.1 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+	{
+		"Id":  "2016_x64_Standard_Nano_EN_Eval",
+		"Filename":  "2016_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2016 Standard Nano 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "Windows Server 2016 SERVERSTANDARDNANO",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+		"Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
+		"CustomData":  {
+			"SetupComplete":  "CoreCLR",
+			"PackagePath":  "\\NanoServer\\Packages",
+			"PackageLocale": "en-US",
+			"WimPath":  "\\NanoServer\\NanoServer.wim",
+			"Package":  [
+				"Microsoft-NanoServer-Guest-Package",
+				"Microsoft-NanoServer-DSC-Package"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
+	},
+	{
+		"Id":  "2016_x64_Datacenter_Nano_EN_Eval",
+		"Filename":  "2016_x64_EN_Eval.iso",
+		"Description":  "Windows Server 2016 Datacenter Nano 64bit English Evaluation",
+		"Architecture":  "x64",
+		"ImageName":  "Windows Server 2016 SERVERDATACENTERNANO",
+		"MediaType":  "ISO",
+		"OperatingSystem":  "Windows",
+		"Uri":  "http://download.microsoft.com/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+		"Checksum":  "70721288BBCDFE3239D8F8C0FAE55F1F",
+		"CustomData":  {
+			"SetupComplete":  "CoreCLR",
+			"PackagePath":  "\\NanoServer\\Packages",
+			"PackageLocale": "en-US",
+			"WimPath":  "\\NanoServer\\NanoServer.wim",
+			"Package":  [
+				"Microsoft-NanoServer-Guest-Package",
+				"Microsoft-NanoServer-DSC-Package"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes":  []
+	},
+	{
+		"Id": "2012R2_x64_Standard_EN_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Standard 64bit English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "2",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Windows8.1-KB2883200-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894029-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894179-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3003057-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3000850-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3014442-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3016437-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+			}
 		]
 	},
-    "Hotfixes": [
-		{
-			"Id": "Windows8.1-KB2883200-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+	{
+		"Id": "2012R2_x64_Standard_EN_V5_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Standard 64bit English Evaluation with WMF 5",
+		"Architecture": "x64",
+		"ImageName": "2",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
 		},
-		{
-			"Id": "Windows8.1-KB2894029-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB2894179-x64.msu",
-			"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3003057-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-		},
-    	{
-			"Id": "Windows8.1-KB3000850-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3014442-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3016437-x64.msu",
-			"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-		}
-	]
-},
-{
-	"Id": "WIN81_x64_Enterprise_EN_V5_Eval",
-    "Filename": "WIN81_x64_ENT_EN_Eval.iso",
-    "Description": "Windows 8.1 64bit Enterprise English Evaluation with WMF 5",
-	"Architecture": "x64",
-	"ImageName": "Windows 8.1 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+			}
 		]
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-		}
-	]
-},
-{
-	"Id": "WIN81_x64_Enterprise_EN_V5_1_Eval",
-    "Filename": "WIN81_x64_ENT_EN_Eval.iso",
-    "Description": "Windows 8.1 64bit Enterprise English Evaluation with WMF 5.1",
-	"Architecture": "x64",
-	"ImageName": "Windows 8.1 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
-	"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+	{
+		"Id": "2012R2_x64_Standard_EN_V5_1_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Standard 64bit English Evaluation with WMF 5.1",
+		"Architecture": "x64",
+		"ImageName": "2",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+			}
 		]
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-			"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-		}
-	]
-},
-{
-	"Id": "WIN81_x86_Enterprise_EN_Eval",
-    "Filename": "WIN81_x86_ENT_EN_Eval.iso",
-    "Description": "Windows 8.1 32bit Enterprise English Evaluation",
-	"Architecture": "x86",
-	"ImageName": "Windows 8.1 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
-	"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+	{
+		"Id": "2012R2_x64_Standard_Core_EN_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Windows8.1-KB2883200-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894029-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894179-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3003057-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3000850-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3014442-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3016437-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+			}
 		]
 	},
-    "Hotfixes": [
-		{
-			"Id": "Windows8.1-KB2883200-x86.msu",
-			"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2883200-x86.msu"
+	{
+		"Id": "2012R2_x64_Standard_Core_EN_V5_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation with WMF 5",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
 		},
-		{
-			"Id": "Windows8.1-KB2894029-x86.msu",
-			"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2894029-x86.msu"
-		},
-		{
-			"Id": "Windows8.1-KB2894179-x86.msu",
-			"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2894179-x86.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3003057-x86.msu",
-			"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3003057-x86.msu"
-		},
-    	{
-			"Id": "Windows8.1-KB3000850-x86.msu",
-			"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3000850-x86.msu"
-		},
-		{
-			"Id": "Windows8.1-KB3014442-x86.msu",
-			"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3014442-x86.msu"
-		}
-	]
-},
-{
-	"Id": "WIN81_x86_Enterprise_EN_V5_Eval",
-    "Filename": "WIN81_x86_ENT_EN_Eval.iso",
-    "Description": "Windows 8.1 32bit Enterprise English Evaluation with WMF 5",
-	"Architecture": "x86",
-	"ImageName": "Windows 8.1 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
-	"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+			}
 		]
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1-KB3134758-x86.msu",
-			"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1-KB3134758-x86.msu"
-		}
-	]
-},
-{
-	"Id": "WIN81_x86_Enterprise_EN_V5_1_Eval",
-    "Filename": "WIN81_x86_ENT_EN_Eval.iso",
-    "Description": "Windows 8.1 32bit Enterprise English Evaluation with WMF 5.1",
-	"Architecture": "x86",
-	"ImageName": "Windows 8.1 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
-	"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+	{
+		"Id": "2012R2_x64_Standard_Core_EN_V5_1_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Standard Core 64bit English Evaluation with WMF 5.1",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+			}
 		]
 	},
-    "Hotfixes": [
-		{
-			"Id": "Win8.1-KB3191564-x86.msu",
-			"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1-KB3191564-x86.msu"
-		}
-	]
-},
-{
-	"Id": "WIN10_x64_Enterprise_21H2_EN_Eval",
-	"Alias": "WIN10_x64_Enterprise_EN_Eval",
-    "Filename": "WIN10_x64_ENT_21H2_EN_Eval.iso",
-    "Description": "Windows 10 64bit Enterprise 2109/21H2 English Evaluation",
-	"Architecture": "x64",
-	"ImageName": "Windows 10 Enterprise Evaluation",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/sg/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
-	"Checksum": "AE1DA210FFFA81BB6A8DF455ECA9636B",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
-		],
-		"MinimumDismVersion": "10.0.0.0"
+	{
+		"Id": "2012R2_x64_Datacenter_EN_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "4",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Windows8.1-KB2883200-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894029-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894179-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3003057-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3000850-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3014442-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3016437-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+			}
+		]
 	},
-    "Hotfixes": []
-},
-{
-	"Id": "WIN10_x86_Enterprise_21H2_EN_Eval",
-	"Alias": "WIN10_x86_Enterprise_EN_Eval",
-    "Filename": "WIN10_x86_ENT_21H2_EN_Eval.iso",
-    "Description": "Windows 10 32bit Enterprise 2109/21H2 English Evaluation",
-	"Architecture": "x86",
-	"ImageName": "Windows 10 Enterprise Evaluation",
-	"MediaType": "ISO",
-	"OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/sg/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
-	"Checksum": "5EE2786AD091B95399A79D46DEF7D43B",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
-		],
-		"MinimumDismVersion": "10.0.0.0"
+	{
+		"Id": "2012R2_x64_Datacenter_EN_V5_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation with WMF 5",
+		"Architecture": "x64",
+		"ImageName": "4",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+			}
+		]
 	},
-    "Hotfixes": []
-},
-{
-	"Id": "WIN10_x64_Enterprise_LTSC_2021_EN_Eval",
-	"Alias": "WIN10_x64_Enterprise_LTSC_EN_Eval",
-    "Filename": "WIN10_x64_ENT_LTSC_2021_EN_Eval.iso",
-    "Description": "Windows 10 64bit Enterprise LTSC 2021 English Evaluation",
-	"Architecture": "x64",
-	"ImageName": "1",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/db/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENT_LTSC_EVAL_x64FRE_en-us.iso",
-	"Checksum": "7E34E331696CA40FEDF657162995C3AD",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
-		],
-		"MinimumDismVersion": "10.0.0.0"
+	{
+		"Id": "2012R2_x64_Datacenter_EN_V5_1_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Datacenter 64bit English Evaluation with WMF 5.1",
+		"Architecture": "x64",
+		"ImageName": "4",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+			}
+		]
 	},
-    "Hotfixes": []
-},
-{
-	"Id": "WIN10_x86_Enterprise_LTSC_2021_EN_Eval",
-	"Alias": "WIN10_x86_Enterprise_LTSC_EN_Eval",
-    "Filename": "WIN10_x86_ENT_LTSC_2021_EN_Eval.iso",
-    "Description": "Windows 10 32bit Enterprise LTSC 2021 English Evaluation",
-	"Architecture": "x86",
-	"ImageName": "1",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/db/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENT_LTSC_EVAL_x86FRE_en-us.iso",
-	"Checksum": "080905D97B178F7FE611BA55531A6CC4",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
-		],
-		"MinimumDismVersion": "10.0.0.0"
+	{
+		"Id": "2012R2_x64_Datacenter_Core_EN_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "3",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Windows8.1-KB2883200-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894029-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894179-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3003057-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3000850-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3014442-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3016437-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+			}
+		]
 	},
-    "Hotfixes": []
-},
-{
-	"Id": "WIN11_x64_Enterprise_21H2_EN_Eval",
-	"Alias": "WIN11_x64_Enterprise_EN_Eval",
-    "Filename": "WIN11_x64_ENT_21H2_EN_Eval.iso",
-    "Description": "Windows 11 64bit Enterprise 21H2 English Evaluation",
-	"Architecture": "x64",
-	"ImageName": "1",
-	"MediaType": "ISO",
-    "OperatingSystem": "Windows",
-	"Uri": "https://software-download.microsoft.com/download/sg/22000.194.210913-1444.co_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
-	"Checksum": "86034E9DA681217E0C7D8A23A27BCF13",
-    "CustomData": {
-		"WindowsOptionalFeature": ["NetFx3"],
-		"CustomBootstrap": [
-			"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
-			"NET USER Administrator /active:yes;",
-			"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
-			"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
-			"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
-		],
-		"MinimumDismVersion": "10.0.0.0"
+	{
+		"Id": "2012R2_x64_Datacenter_Core_EN_V5_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation with WMF 5",
+		"Architecture": "x64",
+		"ImageName": "3",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+			}
+		]
 	},
-    "Hotfixes": []
-}]
+	{
+		"Id": "2012R2_x64_Datacenter_Core_EN_V5_1_Eval",
+		"Filename": "2012R2_x64_EN_Eval.iso",
+		"Description": "Windows Server 2012 R2 Datacenter Core 64bit English Evaluation with WMF 5.1",
+		"Architecture": "x64",
+		"ImageName": "3",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN81_x64_Enterprise_EN_Eval",
+		"Filename": "WIN81_x64_ENT_EN_Eval.iso",
+		"Description": "Windows 8.1 64bit Enterprise English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "Windows 8.1 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Windows8.1-KB2883200-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894029-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894179-x64.msu",
+				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3003057-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3000850-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3014442-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3016437-x64.msu",
+				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN81_x64_Enterprise_EN_V5_Eval",
+		"Filename": "WIN81_x64_ENT_EN_Eval.iso",
+		"Description": "Windows 8.1 64bit Enterprise English Evaluation with WMF 5",
+		"Architecture": "x64",
+		"ImageName": "Windows 8.1 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN81_x64_Enterprise_EN_V5_1_Eval",
+		"Filename": "WIN81_x64_ENT_EN_Eval.iso",
+		"Description": "Windows 8.1 64bit Enterprise English Evaluation with WMF 5.1",
+		"Architecture": "x64",
+		"ImageName": "Windows 8.1 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+		"Checksum": "EE63618E3BE220D86B993C1ABBCF32EB",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN81_x86_Enterprise_EN_Eval",
+		"Filename": "WIN81_x86_ENT_EN_Eval.iso",
+		"Description": "Windows 8.1 32bit Enterprise English Evaluation",
+		"Architecture": "x86",
+		"ImageName": "Windows 8.1 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+		"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Windows8.1-KB2883200-x86.msu",
+				"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2883200-x86.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894029-x86.msu",
+				"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2894029-x86.msu"
+			},
+			{
+				"Id": "Windows8.1-KB2894179-x86.msu",
+				"Uri": "http://download.microsoft.com/download/6/F/C/6FC4B3F3-1103-452F-929D-A9FCABF1AD2B/Windows8.1-KB2894179-x86.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3003057-x86.msu",
+				"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3003057-x86.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3000850-x86.msu",
+				"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3000850-x86.msu"
+			},
+			{
+				"Id": "Windows8.1-KB3014442-x86.msu",
+				"Uri": "http://download.microsoft.com/download/A/5/1/A51119A7-729B-4800-844C-189E2BDCFF85/Windows8.1-KB3014442-x86.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN81_x86_Enterprise_EN_V5_Eval",
+		"Filename": "WIN81_x86_ENT_EN_Eval.iso",
+		"Description": "Windows 8.1 32bit Enterprise English Evaluation with WMF 5",
+		"Architecture": "x86",
+		"ImageName": "Windows 8.1 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+		"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1-KB3134758-x86.msu",
+				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1-KB3134758-x86.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN81_x86_Enterprise_EN_V5_1_Eval",
+		"Filename": "WIN81_x86_ENT_EN_Eval.iso",
+		"Description": "Windows 8.1 32bit Enterprise English Evaluation with WMF 5.1",
+		"Architecture": "x86",
+		"ImageName": "Windows 8.1 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "http://download.microsoft.com/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+		"Checksum": "B2ACCD5F135C3EEDE256D398856AEEAD",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			]
+		},
+		"Hotfixes": [
+			{
+				"Id": "Win8.1-KB3191564-x86.msu",
+				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1-KB3191564-x86.msu"
+			}
+		]
+	},
+	{
+		"Id": "WIN10_x64_Enterprise_21H2_EN_Eval",
+		"Alias": "WIN10_x64_Enterprise_EN_Eval",
+		"Filename": "WIN10_x64_ENT_21H2_EN_Eval.iso",
+		"Description": "Windows 10 64bit Enterprise 2109/21H2 English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "Windows 10 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-download.microsoft.com/download/sg/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+		"Checksum": "AE1DA210FFFA81BB6A8DF455ECA9636B",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN10_x86_Enterprise_21H2_EN_Eval",
+		"Alias": "WIN10_x86_Enterprise_EN_Eval",
+		"Filename": "WIN10_x86_ENT_21H2_EN_Eval.iso",
+		"Description": "Windows 10 32bit Enterprise 2109/21H2 English Evaluation",
+		"Architecture": "x86",
+		"ImageName": "Windows 10 Enterprise Evaluation",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-download.microsoft.com/download/sg/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+		"Checksum": "5EE2786AD091B95399A79D46DEF7D43B",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN10_x64_Enterprise_LTSC_2021_EN_Eval",
+		"Alias": "WIN10_x64_Enterprise_LTSC_EN_Eval",
+		"Filename": "WIN10_x64_ENT_LTSC_2021_EN_Eval.iso",
+		"Description": "Windows 10 64bit Enterprise LTSC 2021 English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-download.microsoft.com/download/db/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENT_LTSC_EVAL_x64FRE_en-us.iso",
+		"Checksum": "7E34E331696CA40FEDF657162995C3AD",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN10_x86_Enterprise_LTSC_2021_EN_Eval",
+		"Alias": "WIN10_x86_Enterprise_LTSC_EN_Eval",
+		"Filename": "WIN10_x86_ENT_LTSC_2021_EN_Eval.iso",
+		"Description": "Windows 10 32bit Enterprise LTSC 2021 English Evaluation",
+		"Architecture": "x86",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-download.microsoft.com/download/db/444969d5-f34g-4e03-ac9d-1f9786c69161/19044.1288.211006-0501.21h2_release_svc_refresh_CLIENT_LTSC_EVAL_x86FRE_en-us.iso",
+		"Checksum": "080905D97B178F7FE611BA55531A6CC4",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN11_x64_Enterprise_22H2_EN_Eval",
+		"Alias": "WIN11_x64_Enterprise_EN_Eval",
+		"Filename": "WIN11_x64_ENT_22H2_EN_Eval.iso",
+		"Description": "Windows 11 64bit Enterprise 22H2 English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/988969d5-f34g-4e03-ac9d-1f9786c66749/22621.382.220806-0833.ni_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+		"Checksum": "31742751015EED1C0197E342E18C64EB",
+		"CustomData": {
+			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	}
+]

--- a/Config/VMDefaults.json
+++ b/Config/VMDefaults.json
@@ -4,7 +4,7 @@
 	"MaximumMemory": 1099511627776,
 	"ProcessorCount": 1,
     "SwitchName": "Default Switch",
-	"Media": "2019_x64_Standard_EN_Eval",
+	"Media": "2022_x64_Datacenter_EN_Eval",
     "TimeZone": "UTC",
     "UILanguage": "en-US",
     "SystemLocale": "en-US",

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.21.0';
+    ModuleVersion     = '0.21.1';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.21.1';
+    ModuleVersion     = '0.22.0';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';


### PR DESCRIPTION
* Adds Windows 11 Enterprise 22H2 (2209) evaluation media
* Adds Adds Windows Server 2022 evaluation media
* Updates default VM media from `2019_x64_Standard_EN_Eval` to `2022_x64_Datacenter_EN_Eval` (#406)