### PR TITLE
Releasing 0.23.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Versions ##
 
-### Unreleased ###
+### 0.23.0 ###
 
 * Fixes PSScriptAnalyzer 1.21.0 test failures
 * Fixes Windows 11 Enterprise 22H2 (2209) evaluation media download link

--- a/Lability.psd1
+++ b/Lability.psd1
@@ -1,10 +1,10 @@
 @{
     RootModule        = 'Lability.psm1';
-    ModuleVersion     = '0.22.0';
+    ModuleVersion     = '0.23.0';
     GUID              = '374126b4-f3d4-471d-b25e-767f69ee03d0';
     Author            = 'Iain Brighton';
     CompanyName       = 'Virtual Engine';
-    Copyright         = '(c) 2021 Virtual Engine Limited. All rights reserved.';
+    Copyright         = '(c) 2023 Virtual Engine Limited. All rights reserved.';
     Description       = 'The Lability module contains cmdlets for provisioning Hyper-V test lab and development environments.';
     PowerShellVersion = '4.0';
     FormatsToProcess  = @('Lability.Format.ps1xml');


### PR DESCRIPTION
* Fixes PSScriptAnalyzer 1.21.0 test failures
* Fixes Windows 11 Enterprise 22H2 (2209) evaluation media download link
* Adds Windows 10 Enterprise 22H2 (2209) evaluation media
* Updates default Windows 10 evaluation media to Windows 10 22H2 (2209)