### PR TITLE
Add's Server 2025 EN & W11 24H2 iso's for EN and EN_GB to Media.json

### DIFF
--- a/Config/Media.json
+++ b/Config/Media.json
@@ -1,5 +1,77 @@
 [
 	{
+		"Id": "2025_x64_Standard_EN_Eval",
+		"Filename": "2025_x64_EN_Eval.iso",
+		"Description": "Windows Server 2025 Standard 64-bit English Evaluation with Desktop Experience",
+		"Architecture": "x64",
+		"ImageName": "2",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1.240331-1435.ge_release_SERVER_EVAL_x64FRE_en-us.iso?culture=en-us&country=US",
+		"Checksum": "8286AE65AB4D6FF2430B914D7901427B",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "2025_x64_Standard_EN_Core_Eval",
+		"Filename": "2025_x64_EN_Eval.iso",
+		"Description": "Windows Server 2025 Standard 64-bit English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1.240331-1435.ge_release_SERVER_EVAL_x64FRE_en-us.iso?culture=en-us&country=US",
+		"Checksum": "8286AE65AB4D6FF2430B914D7901427B",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "2025_x64_Datacenter_EN_Eval",
+		"Filename": "2025_x64_EN_Eval.iso",
+		"Description": "Windows Server 2025 Datacenter 64-bit English Evaluation with Desktop Experience",
+		"Architecture": "x64",
+		"ImageName": "4",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1.240331-1435.ge_release_SERVER_EVAL_x64FRE_en-us.iso?culture=en-us&country=US",
+		"Checksum": "8286AE65AB4D6FF2430B914D7901427B",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "2025_x64_Datacenter_EN_Core_Eval",
+		"Filename": "2025_x64_EN_Eval.iso",
+		"Description": "Windows Server 2025 Datacenter 64-bit English Evaluation in Core mode",
+		"Architecture": "x64",
+		"ImageName": "3",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1.240331-1435.ge_release_SERVER_EVAL_x64FRE_en-us.iso?culture=en-us&country=US",
+		"Checksum": "8286AE65AB4D6FF2430B914D7901427B",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
 		"Id":  "2022_x64_Standard_EN_Eval",
 		"Filename":  "2022_x64_EN_Eval.iso",
 		"Description":  "Windows Server 2022 Standard 64-bit US English Evaluation with Desktop Experience",
@@ -346,6 +418,110 @@
 		"Checksum": "981426E2651BB45D65D528A63B361977",
 		"CustomData": {
 			"WindowsOptionalFeature": ["NetFx3"],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN11_x64_Enterprise_24H2_EN_Eval",
+		"Alias": "WIN11_x64_Enterprise_24H2_EN_Eval",
+		"Filename": "WIN11_x64_ENT_24H2_EN_Eval.iso",
+		"Description": "Windows 11 64-bit Enterprise 24H2 English Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1742.240906-0331.ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+		"Checksum": "CD2F688AB2D4262165AE885B5113CC60",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN11_x64_Enterprise_24H2_ENGB_Eval",
+		"Alias": "WIN11_x64_Enterprise_24H2_ENGB_Eval",
+		"Filename": "WIN11_x64_ENT_24H2_ENGB_Eval.iso",
+		"Description": "Windows 11 64-bit Enterprise 24H2 English GB Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1742.240906-0331.ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-gb.iso",
+		"Checksum": "CDC26A802CE264FB3D2908D70EDBE40B",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN11_x64_Enterprise_LTSC_ENGB_Eval",
+		"Alias": "WIN11_x64_Enterprise_LTSC_ENGB_Eval",
+		"Filename": "WIN11_x64_ENT_LTSC_ENGB_Eval.iso",
+		"Description": "Windows 11 64-bit Enterprise LTSC English GB Evaluation",
+		"Architecture": "x64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1742.240906-0331.ge_release_svc_refresh_CLIENT_LTSC_EVAL_x64FRE_en-gb.iso",
+		"Checksum": "CDC26A802CE264FB3D2908D70EDBE40B",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
+			"CustomBootstrap": [
+				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
+				"NET USER Administrator /active:yes;",
+				"Set-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.PowerShell -Name ExecutionPolicy -Value RemoteSigned -Force; #306",
+				"## Kick-start PowerShell remoting on clients to permit applying DSC configurations",
+				"Enable-PSRemoting -SkipNetworkProfileCheck -Force;"
+			],
+			"MinimumDismVersion": "10.0.0.0"
+		},
+		"Hotfixes": []
+	},
+	{
+		"Id": "WIN11_ARM64_Enterprise_24H2_EN_Eval",
+		"Alias": "WIN11_ARM64_Enterprise__24H2_EN_Eval",
+		"Filename": "WIN11_ARM64_ENT_24H2_EN_Eval.iso",
+		"Description": "Windows 11 ARM 64-bit Enterprise 24H2 English Evaluation",
+		"Architecture": "ARM64",
+		"ImageName": "1",
+		"MediaType": "ISO",
+		"OperatingSystem": "Windows",
+		"Uri": "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1.240331-1435.ge_release_CLIENTENTERPRISEEVAL_OEMRET_A64FRE_en-us.iso",
+		"Checksum": "7BD5CD7F1B41F105B030E483CFDC6377",
+		"CustomData": {
+			"WindowsOptionalFeature": [
+				"NetFx3"
+			],
 			"CustomBootstrap": [
 				"## Unattend.xml will set the Administrator password, but it won't enable the account on client OSes",
 				"NET USER Administrator /active:yes;",


### PR DESCRIPTION
I use both of these ISO's so adding them for use

Closed the last PR as don't know what happened with it and appvayor not working


partially fixes #433 - Seems there's no ISO for EN_GB ARM Win 11 version as it's pointing to en-us or was whilst looking at it