### PR TITLE
Removes legacy Server 2012 R2 media

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Versions ##
 
+### Unreleased ###
+
+* Moves all Windows Server 2012 R2 media to legacy media due to end of support
+* Assigns mounted VHD(X) a drive letter - if not automatically assigned
+
 ### 0.25.0 ###
 
 * Adds Windows 11 Enterprise 23H2 (2310) evaluation media

--- a/Config/LegacyMedia/2012R2_x64_Datacenter_Core_EN_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Datacenter_Core_EN_Eval.json
@@ -1,0 +1,44 @@
+{
+    "Id": "2012R2_x64_Datacenter_Core_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter Core 64-bit English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "3",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Windows8.1-KB2883200-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894029-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894179-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3003057-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3000850-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3014442-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3016437-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Datacenter_Core_EN_V5_1_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Datacenter_Core_EN_V5_1_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Datacenter_Core_EN_V5_1_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter Core 64-bit English Evaluation with WMF 5.1",
+    "Architecture": "x64",
+    "ImageName": "3",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+            "Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Datacenter_Core_EN_V5_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Datacenter_Core_EN_V5_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Datacenter_Core_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter Core 64-bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+    "ImageName": "3",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+            "Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Datacenter_EN_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Datacenter_EN_Eval.json
@@ -1,0 +1,44 @@
+{
+    "Id": "2012R2_x64_Datacenter_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter 64-bit English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "4",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Windows8.1-KB2883200-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894029-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894179-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3003057-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3000850-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3014442-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3016437-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Datacenter_EN_V5_1_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Datacenter_EN_V5_1_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Datacenter_EN_V5_1_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter 64-bit English Evaluation with WMF 5.1",
+    "Architecture": "x64",
+    "ImageName": "4",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+            "Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Datacenter_EN_V5_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Datacenter_EN_V5_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Datacenter_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Datacenter 64-bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+    "ImageName": "4",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+            "Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Standard_Core_EN_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Standard_Core_EN_Eval.json
@@ -1,0 +1,44 @@
+{
+    "Id": "2012R2_x64_Standard_Core_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard Core 64-bit English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "1",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Windows8.1-KB2883200-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894029-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894179-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3003057-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3000850-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3014442-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3016437-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Standard_Core_EN_V5_1_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Standard_Core_EN_V5_1_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Standard_Core_EN_V5_1_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard Core 64-bit English Evaluation with WMF 5.1",
+    "Architecture": "x64",
+    "ImageName": "1",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+            "Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Standard_Core_EN_V5_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Standard_Core_EN_V5_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Standard_Core_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard Core 64-bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+    "ImageName": "1",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+            "Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Standard_EN_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Standard_EN_Eval.json
@@ -1,0 +1,44 @@
+{
+    "Id": "2012R2_x64_Standard_EN_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard 64-bit English Evaluation",
+    "Architecture": "x64",
+    "ImageName": "2",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Windows8.1-KB2883200-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894029-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB2894179-x64.msu",
+            "Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3003057-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3000850-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3014442-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
+        },
+        {
+            "Id": "Windows8.1-KB3016437-x64.msu",
+            "Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Standard_EN_V5_1_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Standard_EN_V5_1_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Standard_EN_V5_1_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard 64-bit English Evaluation with WMF 5.1",
+    "Architecture": "x64",
+    "ImageName": "2",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
+            "Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+        }
+    ]
+}

--- a/Config/LegacyMedia/2012R2_x64_Standard_EN_V5_Eval.json
+++ b/Config/LegacyMedia/2012R2_x64_Standard_EN_V5_Eval.json
@@ -1,0 +1,20 @@
+{
+    "Id": "2012R2_x64_Standard_EN_V5_Eval",
+    "Filename": "2012R2_x64_EN_Eval.iso",
+    "Description": "Windows Server 2012 R2 Standard 64-bit English Evaluation with WMF 5",
+    "Architecture": "x64",
+    "ImageName": "2",
+    "MediaType": "ISO",
+    "OperatingSystem": "Windows",
+    "Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
+    "CustomData": {
+        "WindowsOptionalFeature": ["NetFx3"]
+    },
+    "Hotfixes": [
+        {
+            "Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
+            "Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
+        }
+    ]
+}

--- a/Config/Media.json
+++ b/Config/Media.json
@@ -2,7 +2,7 @@
 	{
 		"Id":  "2022_x64_Standard_EN_Eval",
 		"Filename":  "2022_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2022 Standard 64-bit English Evaluation with Desktop Experience",
+		"Description":  "Windows Server 2022 Standard 64-bit US English Evaluation with Desktop Experience",
 		"Architecture":  "x64",
 		"ImageName":  "2",
 		"MediaType":  "ISO",
@@ -18,7 +18,7 @@
 	{
 		"Id":  "2022_x64_Standard_EN_Core_Eval",
 		"Filename":  "2022_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2022 Standard 64-bit English Evaluation",
+		"Description":  "Windows Server 2022 Standard 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "1",
 		"MediaType":  "ISO",
@@ -34,7 +34,7 @@
 	{
 		"Id":  "2022_x64_Datacenter_EN_Eval",
 		"Filename":  "2022_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2022 Datacenter 64-bit English Evaluation with Desktop Experience",
+		"Description":  "Windows Server 2022 Datacenter 64-bit US English Evaluation with Desktop Experience",
 		"Architecture":  "x64",
 		"ImageName":  "4",
 		"MediaType":  "ISO",
@@ -50,7 +50,7 @@
 	{
 		"Id":  "2022_x64_Datacenter_EN_Core_Eval",
 		"Filename":  "2022_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2022 Datacenter 64-bit English Evaluation in Core mode",
+		"Description":  "Windows Server 2022 Datacenter 64-bit US English Evaluation in Core mode",
 		"Architecture":  "x64",
 		"ImageName":  "3",
 		"MediaType":  "ISO",
@@ -66,7 +66,7 @@
 	{
 		"Id":  "2019_x64_Standard_EN_Eval",
 		"Filename":  "2019_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2019 Standard 64-bit English Evaluation with Desktop Experience",
+		"Description":  "Windows Server 2019 Standard 64-bit US English Evaluation with Desktop Experience",
 		"Architecture":  "x64",
 		"ImageName":  "2",
 		"MediaType":  "ISO",
@@ -82,7 +82,7 @@
 	{
 		"Id":  "2019_x64_Standard_EN_Core_Eval",
 		"Filename":  "2019_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2019 Standard 64-bit English Evaluation",
+		"Description":  "Windows Server 2019 Standard 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "1",
 		"MediaType":  "ISO",
@@ -98,7 +98,7 @@
 	{
 		"Id":  "2019_x64_Datacenter_EN_Eval",
 		"Filename":  "2019_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2019 Datacenter 64-bit English Evaluation with Desktop Experience",
+		"Description":  "Windows Server 2019 Datacenter 64-bit US English Evaluation with Desktop Experience",
 		"Architecture":  "x64",
 		"ImageName":  "4",
 		"MediaType":  "ISO",
@@ -114,7 +114,7 @@
 	{
 		"Id":  "2019_x64_Datacenter_EN_Core_Eval",
 		"Filename":  "2019_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2019 Datacenter 64-bit English Evaluation in Core mode",
+		"Description":  "Windows Server 2019 Datacenter 64-bit US English Evaluation in Core mode",
 		"Architecture":  "x64",
 		"ImageName":  "3",
 		"MediaType":  "ISO",
@@ -130,7 +130,7 @@
 	{
 		"Id":  "2016_x64_Standard_EN_Eval",
 		"Filename":  "2016_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2016 Standard 64-bit English Evaluation",
+		"Description":  "Windows Server 2016 Standard 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "2",
 		"MediaType":  "ISO",
@@ -146,7 +146,7 @@
 	{
 		"Id":  "2016_x64_Standard_Core_EN_Eval",
 		"Filename":  "2016_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2016 Standard Core 64-bit English Evaluation",
+		"Description":  "Windows Server 2016 Standard Core 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "1",
 		"MediaType":  "ISO",
@@ -162,7 +162,7 @@
 	{
 		"Id":  "2016_x64_Datacenter_EN_Eval",
 		"Filename":  "2016_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2016 Datacenter 64-bit English Evaluation",
+		"Description":  "Windows Server 2016 Datacenter 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "4",
 		"MediaType":  "ISO",
@@ -178,7 +178,7 @@
 	{
 		"Id":  "2016_x64_Datacenter_Core_EN_Eval",
 		"Filename":  "2016_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2016 Datacenter Core 64-bit English Evaluation",
+		"Description":  "Windows Server 2016 Datacenter Core 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "3",
 		"MediaType":  "ISO",
@@ -194,7 +194,7 @@
 	{
 		"Id":  "2016_x64_Standard_Nano_EN_Eval",
 		"Filename":  "2016_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2016 Standard Nano 64-bit English Evaluation",
+		"Description":  "Windows Server 2016 Standard Nano 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "Windows Server 2016 SERVERSTANDARDNANO",
 		"MediaType":  "ISO",
@@ -217,7 +217,7 @@
 	{
 		"Id":  "2016_x64_Datacenter_Nano_EN_Eval",
 		"Filename":  "2016_x64_EN_Eval.iso",
-		"Description":  "Windows Server 2016 Datacenter Nano 64-bit English Evaluation",
+		"Description":  "Windows Server 2016 Datacenter Nano 64-bit US English Evaluation",
 		"Architecture":  "x64",
 		"ImageName":  "Windows Server 2016 SERVERDATACENTERNANO",
 		"MediaType":  "ISO",
@@ -238,346 +238,10 @@
 		"Hotfixes":  []
 	},
 	{
-		"Id": "2012R2_x64_Standard_EN_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Standard 64-bit English Evaluation",
-		"Architecture": "x64",
-		"ImageName": "2",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Windows8.1-KB2883200-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894029-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894179-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3003057-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3000850-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3014442-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3016437-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Standard_EN_V5_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Standard 64-bit English Evaluation with WMF 5",
-		"Architecture": "x64",
-		"ImageName": "2",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Standard_EN_V5_1_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Standard 64-bit English Evaluation with WMF 5.1",
-		"Architecture": "x64",
-		"ImageName": "2",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Standard_Core_EN_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Standard Core 64-bit English Evaluation",
-		"Architecture": "x64",
-		"ImageName": "1",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Windows8.1-KB2883200-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894029-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894179-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3003057-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3000850-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3014442-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3016437-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Standard_Core_EN_V5_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Standard Core 64-bit English Evaluation with WMF 5",
-		"Architecture": "x64",
-		"ImageName": "1",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Standard_Core_EN_V5_1_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Standard Core 64-bit English Evaluation with WMF 5.1",
-		"Architecture": "x64",
-		"ImageName": "1",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Datacenter_EN_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Datacenter 64-bit English Evaluation",
-		"Architecture": "x64",
-		"ImageName": "4",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Windows8.1-KB2883200-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894029-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894179-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3003057-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3000850-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3014442-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3016437-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Datacenter_EN_V5_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Datacenter 64-bit English Evaluation with WMF 5",
-		"Architecture": "x64",
-		"ImageName": "4",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Datacenter_EN_V5_1_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Datacenter 64-bit English Evaluation with WMF 5.1",
-		"Architecture": "x64",
-		"ImageName": "4",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Datacenter_Core_EN_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Datacenter Core 64-bit English Evaluation",
-		"Architecture": "x64",
-		"ImageName": "3",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Windows8.1-KB2883200-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2883200-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894029-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894029-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB2894179-x64.msu",
-				"Uri": "http://download.microsoft.com/download/2/7/2/272671E7-44C4-4DC8-BAD0-08A3BF7B08F8/Windows8.1-KB2894179-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3003057-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3003057-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3000850-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3000850-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3014442-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3014442-x64.msu"
-			},
-			{
-				"Id": "Windows8.1-KB3016437-x64.msu",
-				"Uri": "http://download.microsoft.com/download/D/C/6/DC69B595-9C62-4B31-B154-B3722250D296/Windows8.1-KB3016437-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Datacenter_Core_EN_V5_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Datacenter Core 64-bit English Evaluation with WMF 5",
-		"Architecture": "x64",
-		"ImageName": "3",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3134758-x64.msu",
-				"Uri": "https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu"
-			}
-		]
-	},
-	{
-		"Id": "2012R2_x64_Datacenter_Core_EN_V5_1_Eval",
-		"Filename": "2012R2_x64_EN_Eval.iso",
-		"Description": "Windows Server 2012 R2 Datacenter Core 64-bit English Evaluation with WMF 5.1",
-		"Architecture": "x64",
-		"ImageName": "3",
-		"MediaType": "ISO",
-		"OperatingSystem": "Windows",
-		"Uri": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"Checksum": "5B5E08C490AD16B59B1D9FAB0DEF883A",
-		"CustomData": {
-			"WindowsOptionalFeature": ["NetFx3"]
-		},
-		"Hotfixes": [
-			{
-				"Id": "Win8.1AndW2K12R2-KB3191564-x64.msu",
-				"Uri": "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
-			}
-		]
-	},
-	{
 		"Id": "WIN10_x64_Enterprise_22H2_EN_Eval",
 		"Alias": "WIN10_x64_Enterprise_EN_Eval",
 		"Filename": "WIN10_x64_ENT_22H2_EN_Eval.iso",
-		"Description": "Windows 10 64-bit Enterprise 2209/22H2 English Evaluation",
+		"Description": "Windows 10 64-bit Enterprise 2209/22H2 US English Evaluation",
 		"Architecture": "x64",
 		"ImageName": "Windows 10 Enterprise Evaluation",
 		"MediaType": "ISO",
@@ -601,7 +265,7 @@
 		"Id": "WIN10_x86_Enterprise_22H2_EN_Eval",
 		"Alias": "WIN10_x86_Enterprise_EN_Eval",
 		"Filename": "WIN10_x86_ENT_22H2_EN_Eval.iso",
-		"Description": "Windows 10 32-bit Enterprise 2209/22H2 English Evaluation",
+		"Description": "Windows 10 32-bit Enterprise 2209/22H2 US English Evaluation",
 		"Architecture": "x86",
 		"ImageName": "Windows 10 Enterprise Evaluation",
 		"MediaType": "ISO",
@@ -625,7 +289,7 @@
 		"Id": "WIN10_x64_Enterprise_LTSC_2021_EN_Eval",
 		"Alias": "WIN10_x64_Enterprise_LTSC_EN_Eval",
 		"Filename": "WIN10_x64_ENT_LTSC_2021_EN_Eval.iso",
-		"Description": "Windows 10 64-bit Enterprise LTSC 2021 English Evaluation",
+		"Description": "Windows 10 64-bit Enterprise LTSC 2021 US English Evaluation",
 		"Architecture": "x64",
 		"ImageName": "1",
 		"MediaType": "ISO",
@@ -649,7 +313,7 @@
 		"Id": "WIN10_x86_Enterprise_LTSC_2021_EN_Eval",
 		"Alias": "WIN10_x86_Enterprise_LTSC_EN_Eval",
 		"Filename": "WIN10_x86_ENT_LTSC_2021_EN_Eval.iso",
-		"Description": "Windows 10 32-bit Enterprise LTSC 2021 English Evaluation",
+		"Description": "Windows 10 32-bit Enterprise LTSC 2021 US English Evaluation",
 		"Architecture": "x86",
 		"ImageName": "1",
 		"MediaType": "ISO",
@@ -673,7 +337,7 @@
 		"Id": "WIN11_x64_Enterprise_23H2_EN_Eval",
 		"Alias": "WIN11_x64_Enterprise_EN_Eval",
 		"Filename": "WIN11_x64_ENT_23H2_EN_Eval.iso",
-		"Description": "Windows 11 64-bit Enterprise 23H2 English Evaluation",
+		"Description": "Windows 11 64-bit Enterprise 23H2 US English Evaluation",
 		"Architecture": "x64",
 		"ImageName": "1",
 		"MediaType": "ISO",


### PR DESCRIPTION
Moves all Windows Server 2012 R2 media to legacy media due to end of support
Assigns mounted VHD(X) a drive letter - if not automatically assigned