### PR TITLE
Releasing 0.26.0

### DIFF
--- a/Build.PSake.ps1
+++ b/Build.PSake.ps1
@@ -65,7 +65,7 @@ function Set-FileSignatureKeyVault
 
         $azureSignToolArguments += '"{0}"' -f $Path
 
-        $azureSignToolPath = Resolve-Path -Path (Join-Path -Path '~\.dotnet\tools' -ChildPath 'AzureSignTool.exe')
+        $azureSignToolPath = Resolve-Path -Path (Join-Path -Path "$env:USERPROFILE\.dotnet\tools" -ChildPath 'AzureSignTool.exe')
         if (-not (Test-Path -Path $azureSignToolPath -PathType Leaf))
         {
             throw ("Cannot find file '{0}'." -f $azureSignToolPath)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Versions ##
 
-### 0.26.0 (Unreleased) ###
+### 0.26.0 ###
 
 * Adds Windows 11 Enterprise 24H2 (2410) evaluation media
   * Adds EN-US ARM64 media (WIN11_ARM64_Enterprise_24H2_EN_Eval)


### PR DESCRIPTION
* Adds Windows 11 Enterprise 24H2 (2410) evaluation media
  * Adds EN-US ARM64 media (WIN11_ARM64_Enterprise_24H2_EN_Eval)
  * Adds EN-GB x64 media (WIN11_x64_Enterprise_24H2_ENGB_Eval)
* Moves all Windows Server 2012 R2 media to legacy media due to end of support
* Assigns mounted VHD(X) a drive letter - if not automatically assigned
* Updates build pipeline with DotNet Core Azure Sign Tool (and removes VE_Certificate_2023.pfx)